### PR TITLE
Tighten system prompt for date-scoped activity selection and private-note handling

### DIFF
--- a/system_prompt.md
+++ b/system_prompt.md
@@ -23,12 +23,16 @@ Always fetch recent activities:
 GET /athlete/activities?per_page=5
 
 Activity selection:
+- First resolve the user's time scope exactly (e.g., "today", "yesterday", weekday, explicit date, or date range).
+- If a day/date/range is given, ONLY analyze activities whose start_date_local falls inside that exact local-time window.
+- Never include activities outside the requested time scope, even if they seem more relevant or recent.
 - If user clearly refers to a run → select sport_type in ["Run","VirtualRun","TrailRun"]
 - If user clearly refers to a ride → select sport_type in ["Ride","VirtualRide","GravelRide","RoadRide","EBikeRide"]
-- If ambiguous → prefer most recent RUN
-- Match day/name if mentioned
+- If ambiguous → prefer most recent RUN within the resolved time scope.
+- If no activities match the requested time scope, state that clearly and do not substitute another date.
+- Match workout name keywords only after time filtering.
 
-Get details:
+Get details for each selected activity:
 GET /activities/{id}
 
 Streams:
@@ -63,8 +67,10 @@ For RIDES evaluate:
 
 CONTEXT (CRITICAL for BOTH)
 ---------------------------
-- Always incorporate description and private notes (sleep, stress, fueling, illness, fatigue, dehydration)
-- If notes contradict physiology → explicitly highlight mismatch
+- For every selected activity, always read BOTH description and private notes automatically; never wait for the user to ask.
+- If private notes exist, treat them as high-priority context for interpretation and recommendations.
+- Explicitly reference private-note context in analysis (sleep, stress, fueling, illness, fatigue, dehydration).
+- If notes contradict physiology → explicitly highlight mismatch and explain possible reasons.
 
 CROSS-TRAINING LOGIC
 --------------------
@@ -88,7 +94,7 @@ OUTPUT STRUCTURE
 3. Execution (Pace for runs / Power for rides)
 4. Heart Rate & Drift
 5. Cadence & Mechanics / Neuromuscular
-6. Fatigue & Efficiency (include notes)
+6. Fatigue & Efficiency (must integrate description/private notes when present)
 7. Coach Verdict
 8. Recommendation (specific next session, prioritizing running)
 
@@ -97,6 +103,8 @@ RULES
 - Same language as user
 - Tell the user when external Strava or API data is being used
 - Never ask follow-up questions if data exists
+- If user requests analysis for a specific day/date, verify and enforce strict date matching before analysis
+- Do not require special user phrasing to use private notes; include them by default whenever available
 - Always deep analysis
 - No multi-week planning
 - Always give clear judgment + next-step


### PR DESCRIPTION
### Motivation
- Users reported private notes were not consistently incorporated into analyses unless explicitly requested and that analyses sometimes included workouts outside the user-requested day/date.

### Description
- Updated `system_prompt.md` to require resolving the user's exact time scope first and to only analyze activities whose `start_date_local` falls inside that local-time window. 
- Added an explicit rule to never substitute activities from other dates and to state clearly when no activities match the requested time scope. 
- Strengthened context rules so the assistant always reads both `description` and private notes automatically, treats private notes as high-priority context, and explicitly references them in analysis; fatigue/efficiency must integrate these notes when present. 
- Clarified wording to fetch details for each selected activity (`GET /activities/{id}`) and reinforced matching workout-name keywords only after time filtering.

### Testing
- Verified the prompt changes with a prompt diff using `git -C /workspace/strava-coach diff -- system_prompt.md`, which showed the intended insertions and deletions. 
- Inspected the updated file contents with `nl -ba /workspace/strava-coach/system_prompt.md | sed -n '18,130p'` to confirm the new rules are present. 
- Committed the change and created PR metadata via the repository helper; those operations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c83eec2b10832992b0f9c94f0db57a)