### PR TITLE
Add copyable system prompt UI and instructions; update docs and styles

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -76,3 +76,41 @@
   color: rgba(0, 0, 0, 0.68);
   text-align: center;
 }
+
+.prompt-copy-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.6rem;
+}
+
+.prompt-copy-button {
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.9rem;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.prompt-copy-button:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.prompt-copy-status {
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.68);
+}
+
+.prompt-copy-textarea {
+  width: 100%;
+  min-height: 14rem;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+  padding: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  background: #fff;
+  margin-bottom: 1.1rem;
+}

--- a/setup-chatgpt.md
+++ b/setup-chatgpt.md
@@ -38,7 +38,17 @@ If this site is published through GitHub Pages, the action spec URL is typically
 
 [{{ '/actions/strava.openapi.yaml' | absolute_url }}]({{ '/actions/strava.openapi.yaml' | relative_url }})
 
-## 3. Configure OAuth Authentication
+## 3. Add the System Prompt to GPT Instructions
+
+In the GPT builder, open `Configure` and paste the Strava Coach system prompt into the GPT's `Instructions` field.
+
+- Use the copy-ready prompt from [System Prompt]({{ '/system-prompt/' | relative_url }})
+- Paste it into `Instructions` exactly as written
+- Save the GPT configuration after pasting
+
+Without this step, the action may connect successfully but the coaching behavior will not match this project.
+
+## 4. Configure OAuth Authentication
 
 Choose `OAuth` as the authentication type and enter these values exactly:
 
@@ -59,7 +69,18 @@ Choose `OAuth` as the authentication type and enter these values exactly:
   <figcaption>ChatGPT action OAuth configuration</figcaption>
 </figure>
 
-## 4. Final Check
+## 5. Keep Instructions Updated Later
+
+When `system_prompt.md` changes in this repository, update your Custom GPT:
+
+1. Re-open your GPT in ChatGPT.
+2. Copy the latest prompt again from [System Prompt]({{ '/system-prompt/' | relative_url }}).
+3. Replace the full `Instructions` text.
+4. Save and republish the GPT.
+
+Tip: treat `system_prompt.md` as the source of truth and do a full replace rather than partial edits.
+
+## 6. Final Check
 
 Before saving, confirm:
 
@@ -68,5 +89,6 @@ Before saving, confirm:
 - the client ID and secret come from the same Strava app
 - the OAuth scope string matches exactly
 - the token exchange method remains `Default (POST request)`
+- the latest system prompt text is pasted into GPT `Instructions`
 
 Once saved, ChatGPT should prompt the user to connect their Strava account during action authentication.

--- a/system_prompt.md
+++ b/system_prompt.md
@@ -1,11 +1,10 @@
-# System Prompt
+---
+title: System Prompt
+permalink: /system-prompt/
+layout: page
+---
 
-This file is the source of truth for the public `Strava Coach` Custom GPT.
-
-## Prompt Draft
-
-```md
-You are a personal performance coach. Your primary focus is running performance, with cycling used as cross-training to build aerobic capacity and endurance without excess impact.
+{% capture strava_prompt %}You are a personal performance coach. Your primary focus is running performance, with cycling used as cross-training to build aerobic capacity and endurance without excess impact.
 
 You analyze SINGLE workouts from Strava in depth. You support BOTH running and cycling, but running takes priority in interpretation and recommendations.
 
@@ -116,8 +115,24 @@ SAFETY RULES
 - Do not provide medical diagnosis
 - Encourage users to consult a qualified professional for injury, chest pain, fainting, eating disorders, or other high-risk situations
 - Avoid unsafe training guidance, especially for overtraining, dehydration, heat risk, or extreme calorie restriction
-- Refuse requests that would violate privacy, platform rules, or applicable policy
-```
+- Refuse requests that would violate privacy, platform rules, or applicable policy{% endcapture %}
+
+This file is the source of truth for the public `Strava Coach` Custom GPT.
+
+## Copy-ready Prompt
+
+Use this button to copy only the prompt text (without page headings or editing notes):
+
+<div class="prompt-copy-controls">
+  <button type="button" class="prompt-copy-button" data-copy-target="strava-system-prompt">Copy prompt</button>
+  <span class="prompt-copy-status" data-copy-status aria-live="polite"></span>
+</div>
+
+<textarea id="strava-system-prompt" class="prompt-copy-textarea" readonly>{{ strava_prompt | strip }}</textarea>
+
+## Prompt Draft
+
+<pre><code>{{ strava_prompt | strip | escape }}</code></pre>
 
 ## Editing Guidelines
 
@@ -125,3 +140,23 @@ SAFETY RULES
 - Prefer short sections with explicit behavior rules
 - Track substantial behavior changes in pull requests
 - Link prompt changes to issues when they affect user experience or safety
+
+<script>
+  (function () {
+    var button = document.querySelector('[data-copy-target="strava-system-prompt"]');
+    var status = document.querySelector('[data-copy-status]');
+    var source = document.getElementById('strava-system-prompt');
+
+    if (!button || !source || !navigator.clipboard) {
+      return;
+    }
+
+    button.addEventListener('click', function () {
+      navigator.clipboard.writeText(source.value).then(function () {
+        status.textContent = 'Copied.';
+      }).catch(function () {
+        status.textContent = 'Copy failed. Select the text box and copy manually.';
+      });
+    });
+  }());
+</script>


### PR DESCRIPTION
### Motivation

- Provide an easy, copy-ready way for maintainers and users to paste the authoritative system prompt into a Custom GPT's `Instructions` field to ensure consistent behavior. 
- Clarify setup steps for the ChatGPT Strava Action so users include the system prompt when configuring the GPT. 
- Add supporting styles and client-side copy behavior so the prompt UX is intuitive and accessible.

### Description

- Add new styles in `assets/main.scss` for `.prompt-copy-controls`, `.prompt-copy-button`, `.prompt-copy-status`, and `.prompt-copy-textarea` to style the copy UI and textarea. 
- Update `setup-chatgpt.md` to document the required step to paste the system prompt into the GPT `Instructions` and to add guidance for keeping the prompt updated later. 
- Replace `system_prompt.md` content with a Jekyll page that captures the canonical prompt into `strava_prompt`, renders a copy-ready textarea with a `Copy prompt` button, exposes the prompt draft for review, and includes a small client-side script to handle clipboard copying and status messages.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8418556408329b349344cb77302bb)