### PR TITLE
Simplify system_prompt.md editing by removing Liquid capture

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -77,40 +77,80 @@
   text-align: center;
 }
 
-.prompt-copy-controls {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.6rem;
+.prompt-copy-container {
+  position: relative;
+  margin-bottom: 1.1rem;
 }
 
-.prompt-copy-button {
+.prompt-copy-icon-button {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.35rem;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 6px;
-  padding: 0.35rem 0.7rem;
-  font-size: 0.9rem;
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
   background: #ffffff;
   cursor: pointer;
+  z-index: 2;
 }
 
-.prompt-copy-button:hover {
+.prompt-copy-icon-button:hover {
   background: rgba(0, 0, 0, 0.04);
 }
 
-.prompt-copy-status {
-  font-size: 0.85rem;
-  color: rgba(0, 0, 0, 0.68);
+.prompt-copy-toast {
+  position: absolute;
+  top: 0.65rem;
+  right: 2.95rem;
+  border-radius: 999px;
+  padding: 0.22rem 0.6rem;
+  font-size: 0.78rem;
+  background: rgba(0, 0, 0, 0.78);
+  color: #fff;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: opacity 0.16s ease, transform 0.16s ease;
+  pointer-events: none;
 }
 
-.prompt-copy-textarea {
+.prompt-copy-toast--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.prompt-copy-code {
   width: 100%;
   min-height: 14rem;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 8px;
   padding: 0.75rem;
+  padding-right: 5.5rem;
+  margin: 0;
+  white-space: pre;
+  overflow-x: auto;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 0.85rem;
   line-height: 1.35;
   background: #fff;
-  margin-bottom: 1.1rem;
+}
+
+@media screen and (max-width: 600px) {
+  .prompt-copy-icon-button {
+    top: 0.45rem;
+    right: 0.25rem;
+  }
+
+  .prompt-copy-toast {
+    top: 0.45rem;
+    right: 2.65rem;
+  }
+
+  .prompt-copy-code {
+    padding-right: 4.6rem;
+  }
 }

--- a/system_prompt.md
+++ b/system_prompt.md
@@ -4,7 +4,16 @@ permalink: /system-prompt/
 layout: page
 ---
 
-{% capture strava_prompt %}You are a personal performance coach. Your primary focus is running performance, with cycling used as cross-training to build aerobic capacity and endurance without excess impact.
+This file is the source of truth for the public `Strava Coach` Custom GPT.
+
+## Copy-ready Prompt
+
+Use the copy icon in the top-right corner of the prompt block to copy prompt text.
+
+## Prompt Draft
+
+```md
+You are a personal performance coach. Your primary focus is running performance, with cycling used as cross-training to build aerobic capacity and endurance without excess impact.
 
 You analyze SINGLE workouts from Strava in depth. You support BOTH running and cycling, but running takes priority in interpretation and recommendations.
 
@@ -115,24 +124,8 @@ SAFETY RULES
 - Do not provide medical diagnosis
 - Encourage users to consult a qualified professional for injury, chest pain, fainting, eating disorders, or other high-risk situations
 - Avoid unsafe training guidance, especially for overtraining, dehydration, heat risk, or extreme calorie restriction
-- Refuse requests that would violate privacy, platform rules, or applicable policy{% endcapture %}
-
-This file is the source of truth for the public `Strava Coach` Custom GPT.
-
-## Copy-ready Prompt
-
-Use this button to copy only the prompt text (without page headings or editing notes):
-
-<div class="prompt-copy-controls">
-  <button type="button" class="prompt-copy-button" data-copy-target="strava-system-prompt">Copy prompt</button>
-  <span class="prompt-copy-status" data-copy-status aria-live="polite"></span>
-</div>
-
-<textarea id="strava-system-prompt" class="prompt-copy-textarea" readonly>{{ strava_prompt | strip }}</textarea>
-
-## Prompt Draft
-
-<pre><code>{{ strava_prompt | strip | escape }}</code></pre>
+- Refuse requests that would violate privacy, platform rules, or applicable policy
+```
 
 ## Editing Guidelines
 
@@ -143,19 +136,61 @@ Use this button to copy only the prompt text (without page headings or editing n
 
 <script>
   (function () {
-    var button = document.querySelector('[data-copy-target="strava-system-prompt"]');
-    var status = document.querySelector('[data-copy-status]');
-    var source = document.getElementById('strava-system-prompt');
+    var promptBlock = document.querySelector('#prompt-draft + .highlighter-rouge');
+    var promptCode = promptBlock && promptBlock.querySelector('code');
+    var container;
+    var button;
+    var toast;
+    var hideToastTimer;
 
-    if (!button || !source || !navigator.clipboard) {
+    if (!navigator.clipboard || !promptBlock || !promptCode) {
       return;
     }
 
+    promptBlock.classList.add('prompt-copy-code');
+
+    container = promptBlock.parentElement;
+    if (!container.classList.contains('prompt-copy-container')) {
+      container = document.createElement('div');
+      container.className = 'prompt-copy-container';
+      promptBlock.parentElement.insertBefore(container, promptBlock);
+      container.appendChild(promptBlock);
+    }
+
+    button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'prompt-copy-icon-button';
+    button.setAttribute('aria-label', 'Copy prompt text');
+    button.setAttribute('title', 'Copy prompt');
+    button.innerHTML = '<span aria-hidden="true">📋</span>';
+
+    toast = document.createElement('span');
+    toast.className = 'prompt-copy-toast';
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    toast.textContent = 'Copied!';
+
+    container.insertBefore(button, promptBlock);
+    container.insertBefore(toast, promptBlock);
+
+    function showToast(message) {
+      toast.textContent = message;
+      toast.classList.add('prompt-copy-toast--visible');
+
+      if (hideToastTimer) {
+        window.clearTimeout(hideToastTimer);
+      }
+
+      hideToastTimer = window.setTimeout(function () {
+        toast.classList.remove('prompt-copy-toast--visible');
+      }, 1400);
+    }
+
     button.addEventListener('click', function () {
-      navigator.clipboard.writeText(source.value).then(function () {
-        status.textContent = 'Copied.';
+      navigator.clipboard.writeText(promptCode.textContent || '').then(function () {
+        showToast('Copied!');
       }).catch(function () {
-        status.textContent = 'Copy failed. Select the text box and copy manually.';
+        showToast('Copy failed');
       });
     });
   }());


### PR DESCRIPTION
## Summary
- removed the Liquid `{% capture %}` prompt wrapping so `system_prompt.md` now contains plain, directly editable markdown prompt text
- kept a single vanilla fenced code block as the source of the prompt on-page
- moved copy UI wiring to runtime JavaScript: it finds the Prompt Draft code block, wraps it in a copy container, and injects copy icon + toast dynamically
- preserved existing copy behavior (icon click copies prompt text and shows a short toast)

## Testing
- not run (static markdown/js behavior update only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8418556408329b349344cb77302bb)