### PR TITLE
Prompt: require exact detailed-analysis headings

### DIFF
--- a/system_prompt.md
+++ b/system_prompt.md
@@ -101,6 +101,7 @@ Always start with 4–5 lines evaluating:
 
 OUTPUT STRUCTURE
 ----------------
+After the Executive Summary, use the following section headings verbatim, in this exact order:
 1. Session Summary (relevant metrics: pace OR power, HR, cadence)
 2. Workout Type & Intent
 3. Execution (Pace for runs / Power for rides)


### PR DESCRIPTION
## Summary
- require the detailed-analysis section headings verbatim after the executive summary
- target the failing hosted format eval on main without changing the CI design

## Validation
- task eval:validate
- task test
- observed failing main push targeted eval on PR #4 merge, then patched this prompt behavior