### PR TITLE
Fix system prompt publishing to use the raw prompt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Keep the main behavior and policy in `system_prompt.md`. Treat prompt updates li
 - keep edits specific and reviewable
 - document major behavioral changes in commit history
 
-The published copy-ready page lives at:
+The published system prompt page renders that raw file in a copyable block at:
 
 - `https://<github-username>.github.io/<repo-name>/system-prompt/`
 

--- a/content/system-prompt.md
+++ b/content/system-prompt.md
@@ -4,3 +4,11 @@ layout: source-page
 sourceFile: system_prompt.md
 geekdocFilePath: system_prompt.md
 ---
+
+This page publishes the source-of-truth `Strava Coach` system prompt from the
+repository root.
+
+## Copy-ready Prompt
+
+Use the copy button in the top-right corner of the prompt block to copy the
+literal contents of `system_prompt.md`.

--- a/docs/prompt-evals.md
+++ b/docs/prompt-evals.md
@@ -15,6 +15,7 @@ pre-commit hooks.
 - treat hard product requirements as self-grading contract tests
 - use baseline comparison only where the goal is relative improvement
 - publish Promptfoo-native artifacts that are easy to inspect locally and in CI
+- read the candidate prompt directly from the repo-root `system_prompt.md`
 
 ## Directory Layout
 

--- a/evals/promptfoo/prompts.cjs
+++ b/evals/promptfoo/prompts.cjs
@@ -6,10 +6,8 @@ const ROOT = path.resolve(__dirname, '..', '..');
 const CANDIDATE_PROMPT_PATH = path.join(ROOT, 'system_prompt.md');
 const BASELINE_PROMPT_PATH = path.join(ROOT, 'evals', 'prompts', 'system_prompt.baseline.md');
 
-function extractPromptText(filePath) {
-  const text = fs.readFileSync(filePath, 'utf8').trim();
-  const match = text.match(/```(?:md|markdown)?\n([\s\S]*?)\n```/);
-  return (match ? match[1] : text).trim();
+function readPromptText(filePath) {
+  return fs.readFileSync(filePath, 'utf8').trim();
 }
 
 function buildScenarioPrompt(promptText, vars) {
@@ -43,11 +41,11 @@ function buildScenarioPrompt(promptText, vars) {
 }
 
 function candidatePrompt(context) {
-  return buildScenarioPrompt(extractPromptText(CANDIDATE_PROMPT_PATH), context.vars);
+  return buildScenarioPrompt(readPromptText(CANDIDATE_PROMPT_PATH), context.vars);
 }
 
 function baselinePrompt(context) {
-  return buildScenarioPrompt(extractPromptText(BASELINE_PROMPT_PATH), context.vars);
+  return buildScenarioPrompt(readPromptText(BASELINE_PROMPT_PATH), context.vars);
 }
 
 module.exports = {

--- a/evals/promptfoo/prompts.test.cjs
+++ b/evals/promptfoo/prompts.test.cjs
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { baselinePrompt, candidatePrompt } = require('./prompts.cjs');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const CANDIDATE_PROMPT_PATH = path.join(ROOT, 'system_prompt.md');
+const BASELINE_PROMPT_PATH = path.join(ROOT, 'evals', 'prompts', 'system_prompt.baseline.md');
+
+function buildContext() {
+  return {
+    vars: {
+      athlete_profile: 'Runner building back after injury.',
+      strava_data: 'GET /athlete/activities?per_page=5\n[]',
+      user_query: 'Analyze my last run.',
+    },
+  };
+}
+
+test('candidate prompt reads the raw repo-root system prompt file', () => {
+  const promptText = fs.readFileSync(CANDIDATE_PROMPT_PATH, 'utf8').trim();
+  const rendered = candidatePrompt(buildContext());
+
+  assert.ok(rendered.includes(`System instructions:\n${promptText}\nHarness instructions:`));
+  assert.doesNotMatch(rendered, /```/);
+  assert.doesNotMatch(rendered, /This file is the source of truth for the public/);
+});
+
+test('baseline prompt reads the tracked baseline prompt file directly', () => {
+  const promptText = fs.readFileSync(BASELINE_PROMPT_PATH, 'utf8').trim();
+  const rendered = baselinePrompt(buildContext());
+
+  assert.ok(rendered.includes(`System instructions:\n${promptText}\nHarness instructions:`));
+});

--- a/layouts/_default/source-page.html
+++ b/layouts/_default/source-page.html
@@ -7,6 +7,7 @@
   >
     <h1>{{ partial "utils/title" . }}</h1>
     {{ partial "page-metadata" . }}
+    {{ .Content }}
     {{ with .Params.sourceFile }}
       {{ $allowedSourceFiles := dict
         "system_prompt.md" "system_prompt.md"
@@ -15,7 +16,7 @@
       {{ if not $resolvedSourceFile }}
         {{ errorf "unsupported sourceFile %q for %s" . $.File.Path }}
       {{ end }}
-      {{ readFile $resolvedSourceFile | markdownify }}
+      <pre class="prompt-source__block" data-prompt-source-block tabindex="0"><code>{{- readFile $resolvedSourceFile -}}</code></pre>
     {{ end }}
   </article>
 {{ end }}

--- a/static/custom.css
+++ b/static/custom.css
@@ -61,7 +61,7 @@
   font-size: 0.95rem;
 }
 
-.prompt-source pre {
+.prompt-source__block {
   position: relative;
   padding-top: 3.5rem;
 }
@@ -139,7 +139,7 @@
 }
 
 @media screen and (max-width: 45rem) {
-  .prompt-source pre {
+  .prompt-source__block {
     padding-top: 4.75rem;
   }
 

--- a/static/custom.js
+++ b/static/custom.js
@@ -1,10 +1,10 @@
 (() => {
-  const codeBlock = document.querySelector(".prompt-source pre");
-  if (!codeBlock || !navigator.clipboard) {
+  const promptBlock = document.querySelector(".prompt-source [data-prompt-source-block]");
+  if (!promptBlock || !navigator.clipboard) {
     return;
   }
 
-  const textNode = codeBlock.querySelector("code");
+  const textNode = promptBlock.querySelector("code");
   if (!textNode) {
     return;
   }
@@ -21,8 +21,8 @@
   toast.setAttribute("aria-live", "polite");
   toast.textContent = "Copied!";
 
-  codeBlock.appendChild(button);
-  codeBlock.appendChild(toast);
+  promptBlock.appendChild(button);
+  promptBlock.appendChild(toast);
 
   let hideToastTimer = null;
 

--- a/system_prompt.md
+++ b/system_prompt.md
@@ -1,12 +1,3 @@
-This file is the source of truth for the public `Strava Coach` Custom GPT.
-
-## Copy-ready Prompt
-
-Use the copy icon in the top-right corner of the prompt block to copy prompt text.
-
-## Prompt Draft
-
-```md
 You are a personal performance coach. Your primary focus is running performance, with cycling used as cross-training to build aerobic capacity and endurance without excess impact.
 
 You analyze SINGLE workouts from Strava in depth. You support BOTH running and cycling, but running takes priority in interpretation and recommendations.
@@ -142,11 +133,3 @@ SAFETY RULES
 - If the user reports dizziness, faintness, dehydration, heat illness symptoms, or similar acute recovery-risk signals from the current or most recent session, do not prescribe a hard workout for the next day; prioritize recovery, hydration, fueling, cooling, and symptom resolution first
 - Refuse requests that would violate privacy, platform rules, or applicable policy
 - When refusing secret or credential requests, do not include operational examples that could help reconstruct protected access details
-```
-
-## Editing Guidelines
-
-- Keep the prompt readable and easy to diff
-- Prefer short sections with explicit behavior rules
-- Track substantial behavior changes in pull requests
-- Link prompt changes to issues when they affect user experience or safety


### PR DESCRIPTION
## Summary
- make `system_prompt.md` the literal prompt artifact by removing page-only wrapper prose and fenced markdown
- render the published system prompt page from page content plus a generated raw prompt block
- update copy-to-clipboard behavior and prompt eval loading to use the raw file contents directly
- add prompt loader coverage and refresh docs to match the new source-of-truth flow

## Testing
- `task check`
- `task site:build`