### PR TITLE
docs: add repo workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# Strava Coach Repo Instructions
+
+This file adds repo-specific guidance on top of the shared workspace rules.
+Use [`DEVELOPMENT.md`](./DEVELOPMENT.md) for setup and command recipes.
+
+## Purpose
+
+This repository is the codebase for a public `Strava Coach` Custom GPT.
+Most changes are prompt, eval, workflow, or publishing changes rather than app
+runtime code.
+
+## Canonical Interfaces
+
+- Use `task` as the human-facing interface for repo operations.
+- Prefer `task check`, `task site:build`, `task verify`, and the `task eval:*`
+  commands over raw `node`, `promptfoo`, `pre-commit`, or ad hoc shell
+  pipelines.
+- Treat raw scripts under `evals/` and `scripts/` as implementation details
+  unless you are intentionally modifying the plumbing.
+
+## Source Of Truth
+
+- Edit [`system_prompt.md`](./system_prompt.md) for GPT instruction changes.
+- Keep public docs and policy pages under [`content/`](./content/).
+- Keep action schemas in [`actions/`](./actions/).
+- Keep prompt-eval cases and harness code under [`evals/`](./evals/).
+
+## Files And Directories To Treat Carefully
+
+- Do not commit secrets, OAuth credentials, personal data, or raw captured user
+  data.
+- Treat [`evals/reports/`](./evals/reports/), [`public/`](./public/),
+  [`resources/`](./resources/), [`.promptfoo/`](./.promptfoo/),
+  [`node_modules/`](./node_modules/), and [`.playwright/`](./.playwright/) as
+  generated local state unless the task explicitly requires them.
+- Avoid editing [`themes/hugo-geekdoc/`](./themes/hugo-geekdoc/) unless the work
+  is intentionally about the vendored theme.
+- Do not change [`package.json`](./package.json) or
+  [`package-lock.json`](./package-lock.json) unless the dependency/tooling change
+  is intentional. Those files are part of prompt-eval change detection in CI.
+
+## Validation Expectations
+
+- Docs/content-only edits usually need local `pre-commit` or `task check` only
+  when prompt-eval files are involved.
+- Prompt, eval-case, Taskfile, workflow, schema, or fixture-plumbing edits
+  should use the matching `task` command from [`DEVELOPMENT.md`](./DEVELOPMENT.md)
+  before handoff.
+- Do not run hosted Promptfoo tasks without `OPENAI_API_KEY`.
+- Keep non-hosted validation green before asking CI to exercise hosted evals.
+
+## Prompt And Eval Conventions
+
+- Keep prompt edits small, reviewable, and easy to diff.
+- Preserve stable `metadata.id` values in eval cases unless a rename is
+  deliberate and reflected everywhere it matters.
+- Use self-grading cases for hard requirements and compare cases only for
+  baseline-vs-candidate judgments.
+- When changing validation or fixture plumbing, assume whole-tree validation is
+  required, not just changed-file checks.
+
+## Capture And Fixture Safety
+
+- Raw capture commands are for local collection only.
+- Only checked-in, sanitized fixtures belong under the tracked eval fixture
+  paths.
+- Prefer promoting captures through the existing `task capture:*` flow rather
+  than inventing one-off scripts or hand-editing raw transcripts.
+
+## Change Hygiene
+
+- If a PR addresses one or more GitHub issues, mention the affected issue numbers
+  in the relevant commit messages as well as in the PR context.
+- Use a plain reference like `#42` when the commit is part of the issue's work,
+  or a closing keyword like `Fixes #42` when that commit resolves the issue.
+- Only use closing keywords when the merged change fully resolves the issue. If
+  the issue is only partially addressed, reference it without auto-closing it.
+- Keep docs synchronized with workflow changes. If CI behavior or eval policy
+  changes, update [`docs/CI.md`](./docs/CI.md) or
+  [`docs/prompt-evals.md`](./docs/prompt-evals.md) in the same change when
+  needed.
+- Preserve the docs-first tone of the repository: readable Markdown, explicit
+  instructions, and minimal hidden behavior.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,216 @@
+# Development Guide
+
+This file is the concrete setup and validation companion to
+[`AGENTS.md`](./AGENTS.md).
+
+## Recommended Environment
+
+The smoothest path is the included devcontainer. It installs the repo's tool
+chain and wires up the docs preview environment automatically.
+
+Hosted Promptfoo evals also require:
+
+- `OPENAI_API_KEY`
+
+## First-Time Setup
+
+### Devcontainer
+
+Open the repo in the devcontainer and let the post-create step finish. It runs
+[`scripts/devcontainer-post-create.sh`](./scripts/devcontainer-post-create.sh),
+which installs Task, Hugo, `pre-commit`, `ripgrep`, and repo dependencies.
+
+### Local Host
+
+Install the prerequisites, then run:
+
+```bash
+task setup
+```
+
+`task setup`:
+
+- verifies `rg`
+- warns if Hugo is missing
+- installs Node dependencies
+- installs the local `pre-commit` hook when possible
+
+## Daily Commands
+
+List available tasks:
+
+```bash
+task
+```
+
+Fast non-hosted prompt-domain checks:
+
+```bash
+task check
+```
+
+Run pre-commit on all tracked files:
+
+```bash
+task lint:all
+```
+
+Build the production-like Hugo site:
+
+```bash
+task site:build
+```
+
+Run the full non-hosted validation suite:
+
+```bash
+task verify
+```
+
+Start the local docs preview:
+
+```bash
+task serve
+```
+
+To change the preview port:
+
+```bash
+HUGO_PORT=4000 task serve
+```
+
+## What To Run For Common Changes
+
+### Docs Or Content Only
+
+Usually the local hook checks are enough.
+
+If you changed layouts, Hugo config, shortcodes, or publishing behavior, also
+run:
+
+```bash
+task site:build
+```
+
+### `system_prompt.md`, eval harness, or prompt behavior changes
+
+Run:
+
+```bash
+task check
+```
+
+### Eval case YAML changes
+
+Run:
+
+```bash
+task check
+```
+
+The `pre-commit` hook validates changed case files, but `task check` gives you
+the same prompt-domain backstop CI uses.
+
+### Workflow, Taskfile, schema, fixture, or validation-plumbing changes
+
+Run:
+
+```bash
+task verify
+```
+
+## Promptfoo Workflows
+
+Validate case files:
+
+```bash
+task eval:validate
+```
+
+Run the hosted smoke suite:
+
+```bash
+task eval:smoke
+```
+
+Run targeted self-grading evals:
+
+```bash
+task eval:self -- --filter-metadata suite=grounding
+```
+
+Run compare evals:
+
+```bash
+task eval:compare
+```
+
+Run the full hosted suite:
+
+```bash
+task eval:full
+```
+
+Open the local Promptfoo viewer:
+
+```bash
+task eval:view -- -n
+```
+
+Important notes:
+
+- Hosted eval tasks require `OPENAI_API_KEY`.
+- Local artifact output defaults under [`evals/reports/`](./evals/reports/).
+- Promptfoo state under [`.promptfoo/`](./.promptfoo/) is local working state
+  and should not be committed.
+
+## Capture Workflows
+
+Use the existing Taskfile wrappers instead of invoking capture scripts by hand:
+
+```bash
+task capture:strava:auth-url
+task capture:strava:exchange-code -- --code <code>
+task capture:strava:capture -- --label <label> --activity-id <id>
+task capture:gpt -- --scenario <scenario>
+task capture:promote -- --kind <kind> --source <raw.json> --id <fixture-id>
+```
+
+Rules for capture work:
+
+- keep raw captures local
+- check in only sanitized promoted fixtures
+- never commit secrets, OAuth tokens, or personal activity data
+
+## CI Mental Model
+
+The repo uses layered validation:
+
+1. local `pre-commit` for fast changed-file feedback
+2. PR CI for authoritative non-hosted validation
+3. trusted hosted Promptfoo runs for prompt behavior
+4. scheduled/manual hosted runs for broader coverage
+
+Useful references:
+
+- [`docs/CI.md`](./docs/CI.md)
+- [`docs/prompt-evals.md`](./docs/prompt-evals.md)
+- [`.github/workflows/ci.yml`](./.github/workflows/ci.yml)
+- [`.github/workflows/prompt-eval.yml`](./.github/workflows/prompt-eval.yml)
+
+## Repo-Specific Gotchas
+
+- If a PR addresses a GitHub issue, include the issue reference in the relevant
+  commit message too, for example `#42` or `Fixes #42`.
+- Reserve closing keywords like `Fixes #42` for commits and PRs that will fully
+  resolve the issue when merged. Use a non-closing reference when the work is
+  partial.
+- Edit [`system_prompt.md`](./system_prompt.md), not the published wrapper page
+  in [`content/system-prompt.md`](./content/system-prompt.md).
+- Use `task` commands in docs, reviews, and agent responses unless you are
+  deliberately changing the plumbing.
+- Avoid incidental `package-lock.json` churn; lockfile changes affect prompt-eval
+  CI routing.
+- Treat [`public/`](./public/) and [`resources/`](./resources/) as generated.
+- Keep docs updated when workflow behavior changes so future contributors do not
+  have to rediscover the same rules.


### PR DESCRIPTION
## Summary
- add repo-local AGENTS.md guidance for contributors and agents
- add DEVELOPMENT.md with setup, validation, and workflow guidance
- document issue references in commit messages for issue-driven work

Fixes #22
