### PR TITLE
Make local Task runs silent by default outside CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  TASK_SILENT: "0"
+
 jobs:
   pre-commit:
     name: Lint And Validate

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  TASK_SILENT: "0"
+
 concurrency:
   group: pages
   cancel-in-progress: true

--- a/.github/workflows/prompt-eval.yml
+++ b/.github/workflows/prompt-eval.yml
@@ -20,6 +20,9 @@ permissions:
   pull-requests: read
   actions: read
 
+env:
+  TASK_SILENT: "0"
+
 jobs:
   detect-prompt-eval-changes:
     name: Detect Prompt Eval Changes

--- a/.taskrc.yml
+++ b/.taskrc.yml
@@ -1,0 +1,1 @@
+silent: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,6 +43,14 @@ List available tasks:
 task
 ```
 
+Local Task runs are quiet by default so you mostly see the underlying tool
+output. For Task's own command traces while debugging, prefix the command with
+`TASK_SILENT=0`, for example:
+
+```bash
+TASK_SILENT=0 task check
+```
+
 Fast non-hosted prompt-domain checks:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ Use the Taskfile as the stable entrypoint for local validation:
 - `task site:build` validates the production Hugo build
 - `task verify` runs the full non-hosted validation suite
 
+Local Task runs suppress Task's own command echo by default so the underlying
+tool output is easier to read. To turn Task command tracing back on while
+debugging, prefix a command with `TASK_SILENT=0`, for example
+`TASK_SILENT=0 task check`.
+
 A concise “what runs when” guide for developers and QA lives in
 [`docs/CI.md`](./docs/CI.md).
 Use `task` as the canonical interface for repo operations; raw scripts and

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,7 +8,6 @@ tasks:
   default:
     aliases: [list, ls, help]
     desc: List available tasks
-    silent: true
     cmds:
       - task --list
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -12,6 +12,8 @@ hooks can be skipped with `--no-verify`.
 
 Use `task` as the canonical interface for repo operations. `pre-commit` hooks
 and raw `node` scripts are implementation details.
+Local Task runs are quiet by default; GitHub Actions overrides that with
+`TASK_SILENT=0` so CI logs keep Task command traces.
 
 ## What Runs Automatically
 


### PR DESCRIPTION
Fixes #20

## Summary
- Add [`.taskrc.yml`](./.taskrc.yml) to suppress Task command echo locally by default
- Keep GitHub Actions verbose by setting `TASK_SILENT=0` in CI, prompt-eval, and Pages workflows
- Remove the task-specific `silent: true` override from `default` because silence is now configured centrally
- Update contributor docs to explain the new default behavior and the local debug opt-out with `TASK_SILENT=0`

## Testing
- `task setup`
- `task verify`
- `task --dry check`
- `TASK_SILENT=0 task --dry check`