### PR TITLE
Add issue reference enforcement for PRs and commit messages (#26)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Summary
+
+-
+
+## Related Issues
+
+- Reference the issue(s) this PR addresses, for example `#26`
+- Use a closing keyword only when merge should fully resolve the issue
+
+## Testing
+
+-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   pre-commit:
@@ -62,6 +63,13 @@ jobs:
 
       - name: Set up repo tooling
         run: task setup
+
+      - name: Validate PR issue references
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: task ci:issue-refs
 
       - name: Run repo checks for pull requests
         if: github.event_name == 'pull_request'

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -202,6 +202,9 @@ Useful references:
 
 - If a PR addresses a GitHub issue, include the issue reference in the relevant
   commit message too, for example `#42` or `Fixes #42`.
+- If the PR branch name explicitly carries an issue token such as
+  `implement-github-issue-42`, CI will require the PR title or body and every
+  non-merge commit in that PR to reference `#42`.
 - Reserve closing keywords like `Fixes #42` for commits and PRs that will fully
   resolve the issue when merged. Use a non-closing reference when the work is
   partial.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -85,6 +85,11 @@ tasks:
         fi
       - task: site:build
 
+  ci:issue-refs:
+    desc: Validate PR issue references from branch naming, PR context, and commit messages
+    cmds:
+      - node scripts/validate_issue_references.cjs {{.CLI_ARGS}}
+
   ci:prompt:
     desc: Run prompt-domain CI checks
     cmds:
@@ -93,7 +98,7 @@ tasks:
   test:
     desc: Run fast local Promptfoo tests
     cmds:
-      - PROMPTFOO_CONFIG_DIR=.promptfoo PROMPTFOO_DISABLE_WAL_MODE=true node --test $(rg --files evals/promptfoo evals/capture -g '*.test.cjs')
+      - PROMPTFOO_CONFIG_DIR=.promptfoo PROMPTFOO_DISABLE_WAL_MODE=true node --test $(rg --files evals/promptfoo evals/capture scripts -g '*.test.cjs')
 
   eval:validate:
     desc: Validate Promptfoo case files

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -35,6 +35,8 @@ Does not run:
 
 `Lint And Validate`:
 
+- validates PR issue references when the branch name carries an issue token such
+  as `issue-26`
 - re-runs diff-scoped `pre-commit` on the PR diff
 - runs the full Hugo site build
 
@@ -89,6 +91,10 @@ gh workflow run prompt-eval.yml --ref main -f run_nightly_full=true
 ### Docs or content only
 
 Usually nothing beyond local `pre-commit`.
+
+If the branch name includes an issue token such as `issue-42`, make sure the PR
+title or body references that issue and each non-merge commit message does too.
+Use a plain reference like `#42` unless the PR or commit fully resolves it.
 
 If you touched layouts, Hugo config, or rendering behavior, also run:
 
@@ -161,3 +167,15 @@ If you run `pre-commit run -a`, two prompt-validation hooks may both appear:
 - `Validate changed case YAML files` routes changed filenames through `task eval:validate --`
 - `Validate full case tree after validator/schema/fixture changes` is the
   global backstop that exists for validation-plumbing edits
+
+## Issue Reference Guardrail
+
+When a PR branch name explicitly carries an issue number, for example
+`codex/implement-github-issue-26`, CI expects:
+
+- the PR title or body to reference `#26`
+- every non-merge commit in that PR to reference `#26`
+
+The guardrail accepts either a plain issue reference such as `#26` or a full
+issue URL. Prefer a plain reference unless the PR or commit should actually
+close the issue on merge.

--- a/scripts/validate_issue_references.cjs
+++ b/scripts/validate_issue_references.cjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+
+const BRANCH_ISSUE_PATTERNS = [
+  /\b(?:github-)?issues?[-_/](\d+)\b/gi,
+  /\bgh[-_/](\d+)\b/gi,
+  /#(\d+)\b/g,
+];
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      continue;
+    }
+
+    const optionName = token.slice(2);
+    const optionValue = argv[index + 1];
+    if (!optionValue || optionValue.startsWith('--')) {
+      throw new Error(`Missing value for --${optionName}`);
+    }
+
+    options[optionName] = optionValue;
+    index += 1;
+  }
+
+  return options;
+}
+
+function extractBranchIssueNumbers(branchName) {
+  const issueNumbers = new Set();
+
+  for (const pattern of BRANCH_ISSUE_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match = pattern.exec(branchName);
+    while (match) {
+      issueNumbers.add(Number.parseInt(match[1], 10));
+      match = pattern.exec(branchName);
+    }
+  }
+
+  return [...issueNumbers].filter(Number.isFinite).sort((left, right) => left - right);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildIssueReferencePattern(issueNumber) {
+  const issue = escapeRegExp(String(issueNumber));
+  return new RegExp(`(?:#${issue}\\b|issues/${issue}\\b)`, 'i');
+}
+
+function readPullRequestEvent(eventPath) {
+  const payload = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+  if (!payload.pull_request) {
+    throw new Error(`Expected pull_request payload in ${eventPath}`);
+  }
+
+  return payload.pull_request;
+}
+
+function collectPullRequestCommits(baseSha, headSha) {
+  const stdout = execFileSync(
+    'git',
+    ['log', '--format=%H%x00%s%x00%b%x00', '--no-merges', `${baseSha}..${headSha}`],
+    { encoding: 'utf8' },
+  );
+
+  const fields = stdout.split('\u0000');
+  const commits = [];
+  for (let index = 0; index + 2 < fields.length; index += 3) {
+    const sha = fields[index].trim();
+    const subject = fields[index + 1].trim();
+    const body = fields[index + 2].trim();
+
+    if (!sha) {
+      continue;
+    }
+
+    commits.push({
+      sha,
+      subject,
+      body,
+      message: body ? `${subject}\n\n${body}` : subject,
+    });
+  }
+
+  return commits;
+}
+
+function messageContainsIssueReference(message, issueNumber) {
+  return buildIssueReferencePattern(issueNumber).test(message);
+}
+
+function validateIssueReferences({ branchName, prTitle = '', prBody = '', commits = [] }) {
+  const branchIssues = extractBranchIssueNumbers(branchName);
+  if (branchIssues.length === 0) {
+    return {
+      branchIssues,
+      missingPrIssues: [],
+      commitsMissingIssues: [],
+      skipped: true,
+    };
+  }
+
+  const prContext = `${prTitle}\n${prBody}`;
+  const missingPrIssues = branchIssues.filter(
+    (issueNumber) => !messageContainsIssueReference(prContext, issueNumber),
+  );
+
+  const commitsMissingIssues = commits
+    .map((commit) => ({
+      ...commit,
+      missingIssues: branchIssues.filter(
+        (issueNumber) => !messageContainsIssueReference(commit.message, issueNumber),
+      ),
+    }))
+    .filter((commit) => commit.missingIssues.length > 0);
+
+  return {
+    branchIssues,
+    missingPrIssues,
+    commitsMissingIssues,
+    skipped: false,
+  };
+}
+
+function formatIssueList(issueNumbers) {
+  return issueNumbers.map((issueNumber) => `#${issueNumber}`).join(', ');
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const eventPath = options['event-path'] || process.env.GITHUB_EVENT_PATH;
+  const baseSha = options['base-sha'] || process.env.PR_BASE_SHA || process.env.GITHUB_BASE_SHA;
+  const headSha = options['head-sha'] || process.env.PR_HEAD_SHA || process.env.GITHUB_HEAD_SHA;
+
+  if (!eventPath || !baseSha || !headSha) {
+    console.log('Skipping issue reference validation because PR event context is incomplete.');
+    return;
+  }
+
+  const pullRequest = readPullRequestEvent(eventPath);
+  const branchName = pullRequest.head?.ref || '';
+  const commits = collectPullRequestCommits(baseSha, headSha);
+  const result = validateIssueReferences({
+    branchName,
+    prTitle: pullRequest.title || '',
+    prBody: pullRequest.body || '',
+    commits,
+  });
+
+  if (result.skipped) {
+    console.log(`Skipping issue reference validation for branch "${branchName}" because it does not encode an issue number.`);
+    return;
+  }
+
+  const expectedIssues = formatIssueList(result.branchIssues);
+  const failures = [];
+
+  if (result.missingPrIssues.length > 0) {
+    failures.push(
+      `PR title or body must reference ${formatIssueList(result.missingPrIssues)} because branch "${branchName}" encodes ${expectedIssues}.`,
+    );
+  }
+
+  if (result.commitsMissingIssues.length > 0) {
+    failures.push(
+      `Each non-merge commit in the PR must reference ${expectedIssues}. Missing refs:\n${result.commitsMissingIssues
+        .map((commit) => `- ${commit.sha.slice(0, 7)} ${commit.subject}`)
+        .join('\n')}`,
+    );
+  }
+
+  if (failures.length > 0) {
+    throw new Error([
+      'Issue reference validation failed.',
+      'Add a plain reference like "#42" unless the PR or commit fully resolves the issue and should use a closing keyword.',
+      ...failures,
+    ].join('\n\n'));
+  }
+
+  console.log(`Issue reference validation passed for ${expectedIssues} on branch "${branchName}".`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  buildIssueReferencePattern,
+  collectPullRequestCommits,
+  extractBranchIssueNumbers,
+  messageContainsIssueReference,
+  parseArgs,
+  readPullRequestEvent,
+  validateIssueReferences,
+};

--- a/scripts/validate_issue_references.test.cjs
+++ b/scripts/validate_issue_references.test.cjs
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  extractBranchIssueNumbers,
+  messageContainsIssueReference,
+  validateIssueReferences,
+} = require('./validate_issue_references.cjs');
+
+test('extractBranchIssueNumbers finds issue ids from common branch patterns', () => {
+  assert.deepEqual(
+    extractBranchIssueNumbers('codex/implement-github-issue-26'),
+    [26],
+  );
+  assert.deepEqual(
+    extractBranchIssueNumbers('feature/issues/26-improve-ci'),
+    [26],
+  );
+  assert.deepEqual(
+    extractBranchIssueNumbers('codex/gh-12-and-issue-26'),
+    [12, 26],
+  );
+});
+
+test('extractBranchIssueNumbers ignores unrelated numeric branch segments', () => {
+  assert.deepEqual(
+    extractBranchIssueNumbers('release/2026-04'),
+    [],
+  );
+});
+
+test('messageContainsIssueReference accepts issue shorthand and issue urls', () => {
+  assert.equal(messageContainsIssueReference('Implements #26', 26), true);
+  assert.equal(
+    messageContainsIssueReference(
+      'Related: https://github.com/michaelw/strava-coach/issues/26',
+      26,
+    ),
+    true,
+  );
+  assert.equal(messageContainsIssueReference('Mentions #260 instead', 26), false);
+});
+
+test('validateIssueReferences skips branches without explicit issue tokens', () => {
+  const result = validateIssueReferences({
+    branchName: 'docs/update-homepage',
+    prTitle: 'Refresh docs',
+    prBody: '',
+    commits: [],
+  });
+
+  assert.equal(result.skipped, true);
+  assert.deepEqual(result.branchIssues, []);
+});
+
+test('validateIssueReferences requires matching issue refs in PR context and commits', () => {
+  const result = validateIssueReferences({
+    branchName: 'codex/implement-github-issue-26',
+    prTitle: 'Improve CI guardrails',
+    prBody: 'Adds a PR template.',
+    commits: [
+      {
+        sha: 'abc1234',
+        subject: 'ci: add issue reference validator',
+        body: '',
+        message: 'ci: add issue reference validator',
+      },
+      {
+        sha: 'def5678',
+        subject: 'docs: explain issue reference enforcement (#26)',
+        body: '',
+        message: 'docs: explain issue reference enforcement (#26)',
+      },
+    ],
+  });
+
+  assert.deepEqual(result.branchIssues, [26]);
+  assert.deepEqual(result.missingPrIssues, [26]);
+  assert.deepEqual(
+    result.commitsMissingIssues.map((commit) => commit.sha),
+    ['abc1234'],
+  );
+});
+
+test('validateIssueReferences passes when PR context and all commits reference the branch issue', () => {
+  const result = validateIssueReferences({
+    branchName: 'codex/implement-github-issue-26',
+    prTitle: 'ci: enforce issue references in PRs and commits (#26)',
+    prBody: 'Documents the new guardrail.',
+    commits: [
+      {
+        sha: 'abc1234',
+        subject: 'ci: validate PR issue refs (#26)',
+        body: '',
+        message: 'ci: validate PR issue refs (#26)',
+      },
+      {
+        sha: 'def5678',
+        subject: 'docs: document issue ref checks',
+        body: 'Related to #26.',
+        message: 'docs: document issue ref checks\n\nRelated to #26.',
+      },
+    ],
+  });
+
+  assert.deepEqual(result.missingPrIssues, []);
+  assert.deepEqual(result.commitsMissingIssues, []);
+  assert.equal(result.skipped, false);
+});


### PR DESCRIPTION
## Summary
- Add a CI check that validates issue references in PR context and non-merge commit messages when the branch name encodes an issue number
- Add a `task ci:issue-refs` entry point and include the new script test in the existing Node test suite
- Add a pull request template section for related issues and document the guardrail in contributor and CI docs

## Testing
- `task verify`