### PR TITLE
Add Renovate app config for baseline promotions and dependency updates (#28)

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -54,6 +54,7 @@ Same-repo PRs:
 - `Eval Targeted` may run as advisory hosted coverage
 - prompt-eval jobs surface the final outcome and failing case ids directly in
   the eval step output and GitHub step summary
+- Renovate app PRs, including baseline pin bumps, follow this same path
 
 Fork or docs-only PRs:
 
@@ -71,6 +72,21 @@ Prompt-related pushes also run:
 - `Prompt Eval Gate`
 - `Eval Smoke`
 - `Eval Targeted`
+
+### Baseline Release Promotion
+
+Publishing `prompt-baseline-v<semver>` does not change the compare baseline pin
+directly. Instead:
+
+- `baseline-prompt-release.yml` publishes the immutable release artifact
+- Renovate detects that release and opens a PR updating
+  [`evals/config.yaml`](../evals/config.yaml)
+- the generated PR reuses the normal PR validation flow before the new baseline
+  becomes the default compare target
+
+This repository is intended to use the hosted Renovate GitHub App with
+[`renovate.json5`](../renovate.json5), not a self-hosted Renovate Actions
+workflow.
 
 ### Nightly And Manual Hosted Runs
 

--- a/docs/prompt-evals.md
+++ b/docs/prompt-evals.md
@@ -298,10 +298,17 @@ Successful baseline releases are published through
 Normal semver tags like `prompt-baseline-v1.1.0` publish `system_prompt.md` as
 the asset `strava-coach-system-prompt.md`.
 
-When a candidate prompt becomes the new published baseline, publish a new
-semver baseline release and then update the pinned `baseline.url` and
-`baseline.version` in [`evals/config.yaml`](../evals/config.yaml) to that
-release.
+After a new semver baseline release is published, Renovate uses
+[`renovate.json5`](../renovate.json5) to detect that release and
+open a PR which updates both `baseline.version` and `baseline.url` in
+[`evals/config.yaml`](../evals/config.yaml) to the new immutable release
+artifact. That PR then goes through the normal repo validation flow like any
+other prompt-eval change.
+
+This repository expects the hosted Renovate GitHub App rather than a
+self-hosted Renovate workflow. Once the app is installed for the repo, the same
+config also covers the repo's other versioned artifacts such as npm
+dependencies, GitHub Actions references, and pre-commit hooks.
 
 For targeted QA or local experiments, you can override the default source
 without editing tracked files:
@@ -321,15 +328,16 @@ Current pinned baseline:
 1. `prompt-baseline-v1.0.0` already exists as the initial release-backed
    baseline artifact.
 2. [`evals/config.yaml`](../evals/config.yaml) stays pinned to that release URL
-   until a newer baseline release is intentionally promoted.
+   until a newer baseline release is intentionally promoted by the Renovate PR.
 
 Future releases:
 
 1. Publish a new `prompt-baseline-v<semver>` release from `system_prompt.md`.
-2. Update the pinned `baseline.url` and `baseline.version` in
-   [`evals/config.yaml`](../evals/config.yaml).
-3. Run `task check` or `task verify` before handoff so the new URL resolves in
-   the same way CI will use it.
+2. Let Renovate open the PR that updates
+   [`evals/config.yaml`](../evals/config.yaml) to that release.
+3. Review the generated PR and let the existing CI validate the updated pin.
+4. If Renovate has not opened the PR yet, check that the Renovate GitHub App is
+   installed for this repository and that it has processed the new release.
 
 CI may produce additional per-suite files such as `self.smoke.json` or
 `compare.personalization.json` when it loops changed suites on trusted `main`

--- a/evals/promptfoo/promptfoo_configs.test.cjs
+++ b/evals/promptfoo/promptfoo_configs.test.cjs
@@ -10,6 +10,7 @@ const {
   readRetryPolicy,
   readYaml,
 } = require('./config.cjs');
+const { deriveVersionFromUrl } = require('../prompts/baseline.cjs');
 
 const SELF_CONFIG_PATH = path.resolve('evals/promptfoo/promptfooconfig.self.yaml');
 const COMPARE_CONFIG_PATH = path.resolve('evals/promptfoo/promptfooconfig.compare.yaml');
@@ -70,11 +71,11 @@ test('repo config exposes retry defaults for hosted eval reruns', () => {
 test('repo config exposes the pinned baseline artifact source', () => {
   const repoConfig = readRepoConfig();
   const baselineConfig = readBaselineConfig();
+  const expectedUrl = `https://github.com/michaelw/strava-coach/releases/download/prompt-baseline-v${repoConfig.baseline.version}/strava-coach-system-prompt.md`;
 
-  assert.deepEqual(repoConfig.baseline, {
-    version: '1.0.0',
-    url: 'https://github.com/michaelw/strava-coach/releases/download/prompt-baseline-v1.0.0/strava-coach-system-prompt.md',
-  });
+  assert.match(repoConfig.baseline.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(repoConfig.baseline.url, expectedUrl);
+  assert.equal(deriveVersionFromUrl(repoConfig.baseline.url), repoConfig.baseline.version);
   assert.deepEqual(baselineConfig, repoConfig.baseline);
   assert.deepEqual(DEFAULT_BASELINE_CONFIG, {
     version: '',

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,41 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['config:recommended'],
+  dependencyDashboard: false,
+  enabledManagers: ['npm', 'github-actions', 'pre-commit', 'custom.regex'],
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'Update the pinned compare baseline release in evals/config.yaml',
+      managerFilePatterns: ['/^evals\\/config\\.yaml$/'],
+      matchStrings: [
+        'baseline:\\s*\\n(?<indentation>[ \\t]*)version:\\s(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s*\\n[ \\t]*url:\\shttps://github\\.com/michaelw/strava-coach/releases/download/prompt-baseline-v\\d+\\.\\d+\\.\\d+/strava-coach-system-prompt\\.md',
+      ],
+      autoReplaceStringTemplate:
+        'baseline:\n{{{indentation}}}version: {{{newValue}}}\n{{{indentation}}}url: https://github.com/michaelw/strava-coach/releases/download/prompt-baseline-v{{{newValue}}}/strava-coach-system-prompt.md',
+      depNameTemplate: 'michaelw/strava-coach',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^prompt-baseline-v(?<version>.*)$',
+      versioningTemplate: 'semver',
+    },
+  ],
+  packageRules: [
+    {
+      matchManagers: ['github-actions'],
+      groupName: 'github actions',
+    },
+    {
+      matchManagers: ['npm'],
+      groupName: 'npm dev dependencies',
+    },
+    {
+      matchManagers: ['pre-commit'],
+      groupName: 'pre-commit hooks',
+    },
+    {
+      matchManagers: ['custom.regex'],
+      commitMessageTopic: 'prompt baseline release',
+      groupName: 'prompt baseline release',
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- add `renovate.json5` for hosted Renovate app management of npm, GitHub Actions, pre-commit, and baseline release bumps
- automate `evals/config.yaml` baseline version and URL updates from `prompt-baseline-v*.*.*` GitHub releases
- update prompt eval and CI docs to describe the Renovate-driven promotion flow
- make the baseline config test derive and validate the pinned release URL dynamically for future baseline versions

## Testing
- `task verify`