### PR TITLE
Rename task serve references to task site:serve

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Hugo Serve",
       "type": "shell",
-      "command": "if [ -f /.dockerenv ]; then task serve; else echo 'Skipping Hugo Serve auto-start (not running inside a devcontainer).'; fi",
+      "command": "if [ -f /.dockerenv ]; then task site:serve; else echo 'Skipping Hugo Serve auto-start (not running inside a devcontainer).'; fi",
       "isBackground": true,
       "problemMatcher": {
         "owner": "hugo",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,13 +78,13 @@ task verify
 Start the local docs preview:
 
 ```bash
-task serve
+task site:serve
 ```
 
 To change the preview port:
 
 ```bash
-HUGO_PORT=4000 task serve
+HUGO_PORT=4000 task site:serve
 ```
 
 ## What To Run For Common Changes

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ You can preview the GitHub Pages site locally inside a devcontainer.
 3. Start the Hugo server:
 
 ```bash
-task serve
+task site:serve
 ```
 
 Optional: this repository includes a VS Code task named `Hugo Serve` in `.vscode/tasks.json` that can auto-start on folder open if automatic tasks are allowed.
@@ -177,7 +177,7 @@ Then open the forwarded site at `http://127.0.0.1:1313/`.
 The preview server defaults to Hugo's standard port `1313`. To use a different local port, set `HUGO_PORT` in your shell or in `.env`, for example:
 
 ```bash
-HUGO_PORT=4000 task serve
+HUGO_PORT=4000 task site:serve
 ```
 
 The devcontainer forwards:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -171,7 +171,7 @@ tasks:
       - task: check
       - task: site:build
 
-  serve:
+  site:serve:
     desc: Start the local Hugo preview server
     deps:
       - _require_hugo
@@ -247,6 +247,6 @@ tasks:
     cmds:
       - |
         if ! command -v hugo >/dev/null 2>&1; then
-          echo "Hugo is required for task serve and task site:build. Install Hugo or use the devcontainer." >&2
+          echo "Hugo is required for task site:* targets. Install Hugo or use the devcontainer." >&2
           exit 1
         fi


### PR DESCRIPTION
Closes #30

## Summary
- rename the Hugo preview task from task serve to task site:serve
- update repo docs and examples to use the new task name
- update the VS Code devcontainer helper task and Hugo requirement message for consistency

## Validation
- task verify