### PR TITLE
fix: repeated missing Strava stream note on ride analysis

### DIFF
--- a/actions/strava.openapi.yaml
+++ b/actions/strava.openapi.yaml
@@ -19,7 +19,7 @@ paths:
           content:
             application/json:
               schema:
-                "": '#/components/schemas/Athlete'
+                $ref: '#/components/schemas/Athlete'
   /athlete/zones:
     get:
       operationId: getAthleteZones
@@ -88,7 +88,7 @@ paths:
               schema:
                 type: array
                 items:
-                  "": '#/components/schemas/ActivitySummary'
+                  $ref: '#/components/schemas/ActivitySummary'
   /activities/{id}:
     get:
       operationId: getActivityById
@@ -112,7 +112,7 @@ paths:
           content:
             application/json:
               schema:
-                "": '#/components/schemas/ActivityDetail'
+                $ref: '#/components/schemas/ActivityDetail'
   /activities/{id}/streams:
     get:
       operationId: getActivityStreams
@@ -140,21 +140,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties: {}
-                additionalProperties:
-                  type: object
-                  properties:
-                    original_size:
-                      type: integer
-                    resolution:
-                      type: string
-                    series_type:
-                      type: string
-                    data:
-                      type: array
-                      items:
-                        type: number
+                oneOf:
+                  - $ref: '#/components/schemas/ActivityStreams'
+                  - $ref: '#/components/schemas/StreamErrorResponse'
   /activities/{id}/zones:
     get:
       operationId: getActivityZones
@@ -218,6 +206,15 @@ components:
         start_date:
           type: string
           format: date-time
+        start_date_local:
+          type: string
+          format: date-time
+        average_speed:
+          type: number
+        average_heartrate:
+          type: number
+        average_watts:
+          type: number
         visibility:
           type: string
           enum:
@@ -248,6 +245,11 @@ components:
         start_date:
           type: string
           format: date-time
+        start_date_local:
+          type: string
+          format: date-time
+        average_speed:
+          type: number
         visibility:
           type: string
           enum:
@@ -264,6 +266,41 @@ components:
           type: number
         max_heartrate:
           type: number
+    ActivityStreams:
+      type: object
+      description: Mapping of stream type to time-series payloads keyed by stream name.
+      additionalProperties:
+        $ref: '#/components/schemas/ActivityStream'
+    ActivityStream:
+      type: object
+      properties:
+        original_size:
+          type: integer
+        resolution:
+          type: string
+        series_type:
+          type: string
+        data:
+          type: array
+          items:
+            oneOf:
+              - type: number
+              - type: array
+                minItems: 2
+                maxItems: 2
+                items:
+                  type: number
+      required:
+        - data
+      additionalProperties: true
+    StreamErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+      required:
+        - error
+      additionalProperties: true
   securitySchemes:
     stravaOAuth:
       type: oauth2

--- a/evals/cases/self/grounding/grounding-005.yaml
+++ b/evals/cases/self/grounding/grounding-005.yaml
@@ -1,0 +1,29 @@
+description: Do not broadly claim ride streams failed when the fixture includes usable ride stream data.
+vars:
+  athlete_profile: |
+    Runner using cycling as cross-training and wanting a data-backed ride review.
+  strava_fixture: production/strava/cross-training-ride.json
+  user_query: |
+    Analyze my last ride.
+assert:
+  - type: not-icontains-any
+    metric: grounding
+    value:
+      - didn't come through
+      - did not come through
+      - streams failed
+  - type: llm-rubric
+    metric: grounding
+    value: The response recognizes that usable ride stream data is available in the fixture and does not broadly claim that the ride lacked detailed time-series data.
+  - type: llm-rubric
+    metric: grounding
+    value: The response bases the ride analysis on the available stream-backed evidence such as power or heart-rate trends, while staying honest about any specific channels that are absent.
+metadata:
+  id: grounding-005
+  suite: grounding
+  priority: high
+  tags:
+    - ride
+    - streams
+    - regression
+  rationale: When ride streams are present, the coach should use them instead of defaulting to a missing-stream disclaimer.

--- a/scripts/strava_openapi.test.cjs
+++ b/scripts/strava_openapi.test.cjs
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const specPath = path.join(__dirname, '..', 'actions', 'strava.openapi.yaml');
+const spec = yaml.load(fs.readFileSync(specPath, 'utf8'));
+
+test('core Strava responses use explicit $ref schemas', () => {
+  assert.equal(
+    spec.paths['/athlete'].get.responses['200'].content['application/json'].schema.$ref,
+    '#/components/schemas/Athlete',
+  );
+  assert.equal(
+    spec.paths['/athlete/activities'].get.responses['200'].content['application/json'].schema.items.$ref,
+    '#/components/schemas/ActivitySummary',
+  );
+  assert.equal(
+    spec.paths['/activities/{id}'].get.responses['200'].content['application/json'].schema.$ref,
+    '#/components/schemas/ActivityDetail',
+  );
+});
+
+test('activity schemas cover fields used by tracked fixtures', () => {
+  const summaryProperties = spec.components.schemas.ActivitySummary.properties;
+  const detailProperties = spec.components.schemas.ActivityDetail.properties;
+
+  assert.ok(summaryProperties.start_date_local);
+  assert.ok(summaryProperties.average_speed);
+  assert.ok(summaryProperties.average_heartrate);
+  assert.ok(summaryProperties.average_watts);
+
+  assert.ok(detailProperties.start_date_local);
+  assert.ok(detailProperties.average_speed);
+  assert.ok(detailProperties.average_heartrate);
+  assert.ok(detailProperties.average_watts);
+});
+
+test('activity streams response distinguishes usable streams from explicit errors', () => {
+  const streamResponseSchema =
+    spec.paths['/activities/{id}/streams'].get.responses['200'].content['application/json'].schema;
+
+  assert.equal(streamResponseSchema.oneOf.length, 2);
+  assert.deepEqual(
+    streamResponseSchema.oneOf.map((entry) => entry.$ref),
+    [
+      '#/components/schemas/ActivityStreams',
+      '#/components/schemas/StreamErrorResponse',
+    ],
+  );
+
+  const streamSchema = spec.components.schemas.ActivityStream;
+  assert.deepEqual(streamSchema.required, ['data']);
+  assert.equal(streamSchema.properties.data.type, 'array');
+  assert.deepEqual(
+    streamSchema.properties.data.items.oneOf.map((entry) => entry.type),
+    ['number', 'array'],
+  );
+});

--- a/system_prompt.md
+++ b/system_prompt.md
@@ -44,7 +44,14 @@ keys = "time,watts,heartrate,cadence,distance"
 
 key_by_type = true
 
-If streams fail → use summary data and state limitation.
+Only say stream-level data is unavailable when GET /activities/{id}/streams
+returns an explicit error, an empty object, or no usable requested data arrays.
+If at least one requested stream is present, treat streams as available, use the
+available channels, and do NOT claim that the detailed time-series data failed
+to come through.
+If streams fail entirely → use summary data and state that limitation.
+If only some stream types are missing → use the available ones and mention only
+the specific missing channels if that materially changes the analysis.
 If duration >2h → downsample.
 
 ANALYSIS


### PR DESCRIPTION
Update the OpenAPI schema references and enhance activity stream handling to prevent incorrect claims about missing ride stream data when valid data is available.

## Related Issues

- Fixes #53

## Testing

Add regression coverage to ensure that usable ride stream data is recognized and that the fallback message is only used when appropriate.

