### PR TITLE
Update issue implementation policy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ runtime code.
 
 - When asked to implement a GitHub issue, start by linking the issue and
   printing its title before beginning the implementation work.
+- Unless the user explicitly asks otherwise, base GitHub issue implementation
+  work on the latest upstream default branch before making changes.
+- When implementation work on a GitHub issue begins, set the issue assignee to
+  the person doing the work.
 - If a PR addresses one or more GitHub issues, mention the affected issue numbers
   in the relevant commit messages as well as in the PR context.
 - Use a plain reference like `#42` by default when the work is part of the


### PR DESCRIPTION
## Summary
- clarify that GitHub issue implementation should start from the latest upstream default branch unless directed otherwise
- require setting the issue assignee when implementation work begins

## Testing
- Not run (not requested)