### PR TITLE
Fix OpenAI import compatibility in Strava OpenAPI spec

### DIFF
--- a/actions/strava.openapi.yaml
+++ b/actions/strava.openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: Strava API v3
   description: The [Swagger Playground](https://developers.strava.com/playground) is the easiest way to familiarize yourself with the Strava API by submitting HTTP requests and observing the responses before you write any client code. It will show what a response will look like with different endpoints depending on the authorization scope you receive from your athletes. To use the Playground, go to https://www.strava.com/settings/api and change your “Authorization Callback Domain” to developers.strava.com. Please note, we only support Swagger 2.0. There is a known issue where you can only select one scope at a time. For more information, please check the section “client code” at https://developers.strava.com/docs.
@@ -135,12 +135,7 @@ paths:
     get:
       operationId: getActivityById
       summary: Get Activity
-      description: |-
-        Returns the given activity that is owned by the authenticated athlete. Requires activity:read for Everyone and Followers activities. Requires activity:read_all for Only Me activities.
-
-        We strongly encourage you to display the appropriate attribution that identifies Garmin as the data source and the device name in your application. Please see example below from VeloViewer (that provides an attribution for a Garmin Forerunner device).
-
-        ![Attribution](/images/device-attribution-image.png)
+      description: Returns the given activity that is owned by the authenticated athlete. Requires activity:read for Everyone and Followers activities and activity:read_all for Only Me activities.
       tags:
         - Activities
       security:
@@ -595,7 +590,7 @@ components:
         score:
           type: integer
         distribution_buckets:
-          $ref: '#/TimedZoneDistribution'
+          $ref: '#/components/schemas/TimedZoneDistribution'
         type:
           type: string
           enum:
@@ -609,6 +604,20 @@ components:
           type: boolean
         max:
           type: integer
+    TimedZoneDistribution:
+      type: array
+      items:
+        type: object
+        properties:
+          min:
+            type: integer
+            description: The lower bound of the zone range.
+          max:
+            type: integer
+            description: The upper bound of the zone range.
+          time:
+            type: integer
+            description: The number of seconds spent in the zone range.
     SummaryAthlete:
       allOf:
         - $ref: '#/components/schemas/MetaAthlete'


### PR DESCRIPTION
### Motivation
- The OpenAI actions importer requires OpenAPI `3.1.0`/`3.1.1` and was rejecting the spec which declared `3.0.3`.
- One operation description exceeded the importer's 300-character limit and a referenced `TimedZoneDistribution` schema was missing/incorrectly referenced, causing import errors.

### Description
- Updated the document `openapi` version to `3.1.0` in `actions/strava.openapi.yaml`.
- Shortened the `description` for the `GET /activities/{id}` (`operationId: getActivityById`) to keep it under 300 characters.
- Fixed `ActivityZone.distribution_buckets` to reference `#/components/schemas/TimedZoneDistribution` instead of an invalid root ref.
- Added a concrete `TimedZoneDistribution` schema under `components.schemas` as an array of objects with `min`, `max`, and `time` properties.

### Testing
- Ran a YAML inspection with `ruby -ryaml -e 'doc=YAML.load_file("actions/strava.openapi.yaml");op=doc.dig("paths","/activities/{id}","get"); puts "description_length=#{op["description"].length}"; puts "openapi=#{doc["openapi"]}"; puts "timed_zone_schema_type=#{doc.dig("components","schemas","TimedZoneDistribution","type")}"'`, which reported the shortened description length, `openapi=3.1.0`, and `TimedZoneDistribution` type `array` (success).
- `task check`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2786bd908832995fb9fc3b2f872c5)