### PR TITLE
Fix Renovate config validation and add a guardrail for future edits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,11 @@ repos:
     rev: 0.33.2
     hooks:
       - id: check-github-workflows
-
+      - id: check-renovate
+        name: Validate Renovate config
+        files: ^renovate\.json5$
+        additional_dependencies:
+          - pyjson5
   - repo: local
     hooks:
       - id: validate-changed-case-yaml-files

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,6 +80,12 @@ Run pre-commit on all tracked files:
 task lint:all
 ```
 
+Validate the Renovate config directly:
+
+```bash
+task renovate:validate
+```
+
 Build the production-like Hugo site:
 
 ```bash
@@ -136,7 +142,7 @@ task check
 The `pre-commit` hook validates changed case files, but `task check` gives you
 the same prompt-domain backstop CI uses.
 
-### Workflow, Taskfile, schema, fixture, or validation-plumbing changes
+### Workflow, Taskfile, Renovate config, schema, fixture, or validation-plumbing changes
 
 Run:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,6 +75,11 @@ tasks:
     cmds:
       - pre-commit run --from-ref "${PRE_COMMIT_FROM_REF}" --to-ref "${PRE_COMMIT_TO_REF}"
 
+  renovate:validate:
+    desc: Validate the Renovate configuration
+    cmds:
+      - PRE_COMMIT_HOME="${PRE_COMMIT_HOME:-${TMPDIR:-/tmp}/strava-coach-pre-commit}" pre-commit run check-renovate --files renovate.json5
+
   ci:repo:
     desc: Run repo-wide non-hosted CI checks
     cmds:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -24,6 +24,7 @@ Runs only on staged files.
 Typical checks:
 
 - Markdown, YAML, JSON, and workflow syntax/hygiene
+- Renovate config validation when [`renovate.json5`](../renovate.json5) changes
 - changed case YAML validation for `evals/cases/**/*.yaml`
 - full-tree case validation when validator/schema/fixture plumbing changes
 
@@ -40,6 +41,7 @@ Does not run:
 - validates PR issue references when the branch name carries an issue token such
   as `issue-26`
 - re-runs diff-scoped `pre-commit` on the PR diff
+- validates [`renovate.json5`](../renovate.json5) with the pre-commit Renovate schema hook
 - runs the full Hugo site build
 
 `Prompt Eval Gate`:
@@ -70,6 +72,7 @@ Fork or docs-only PRs:
 `Lint And Validate`:
 
 - full-repo `pre-commit`
+- Renovate config validation via the pre-commit schema hook
 - full Hugo site build
 
 Prompt-related pushes also run:
@@ -221,6 +224,9 @@ If you run `pre-commit run -a`, two prompt-validation hooks may both appear:
 - `Validate changed case YAML files` routes changed filenames through `task eval:validate --`
 - `Validate full case tree after validator/schema/fixture changes` is the
   global backstop that exists for validation-plumbing edits
+
+If [`renovate.json5`](../renovate.json5) is staged, `Validate Renovate config`
+runs `task renovate:validate` so schema and parser errors fail before push.
 
 ## Issue Reference Guardrail
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,7 +7,7 @@
     {
       customType: 'regex',
       description: 'Update the pinned compare baseline release in evals/config.yaml',
-      managerFilePatterns: ['/^evals\\/config\\.yaml$/'],
+      fileMatch: ['^evals/config\\.yaml$'],
       matchStrings: [
         'baseline:\\s*\\n(?<indentation>[ \\t]*)version:\\s(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s*\\n[ \\t]*url:\\shttps://github\\.com/michaelw/strava-coach/releases/download/prompt-baseline-v\\d+\\.\\d+\\.\\d+/strava-coach-system-prompt\\.md',
       ],
@@ -21,12 +21,10 @@
     {
       customType: 'regex',
       description:
-        'Update pinned tool versions annotated with renovate comments. ' +
-        'Add a "# renovate: datasource=... depName=... extractVersion=..." comment ' +
-        'above any UPPERCASE_TOOL_VERSION variable to have it tracked here.',
-      managerFilePatterns: [
-        '/^scripts\\/devcontainer-post-create\\.sh$/',
-        '/^\\.github\\/workflows\\/ci\\.yml$/',
+        'Update pinned tool versions annotated with renovate comments. Add a "# renovate: datasource=... depName=... extractVersion=..." comment above any UPPERCASE_TOOL_VERSION variable to have it tracked here.',
+      fileMatch: [
+        '^scripts/devcontainer-post-create\\.sh$',
+        '^\\.github/workflows/ci\\.yml$',
       ],
       matchStrings: [
         '\\s*# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: extractVersion=(?<extractVersion>[^\\s]+))?\\n\\s*[A-Z_]+_VERSION(?:=|: )"?(?<currentValue>[\\d.]+)"?',


### PR DESCRIPTION
## Summary
- Fix `renovate.json5` so the custom regex managers use valid `fileMatch` fields and valid JSON5 string syntax
- Add a `check-renovate` pre-commit hook with `pyjson5` so Renovate config errors fail on staged changes
- Add `task renovate:validate` and document the new validation path in [`DEVELOPMENT.md`](DEVELOPMENT.md) and [`docs/CI.md`](docs/CI.md)
- Fixes #73

## Testing
- `task renovate:validate`