### PR TITLE
Fix Strava OpenAPI sync drift

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,7 +67,8 @@ Fast non-hosted prompt-domain checks:
 task check
 ```
 
-Regenerate the local Strava OpenAPI subset from Strava's published Swagger:
+Regenerate the local Strava OpenAPI subset from Strava's published Swagger and
+reapply the local OpenAI action importer compatibility transforms:
 
 ```bash
 task openapi:sync
@@ -143,7 +144,8 @@ Run:
 task verify
 ```
 
-If you are updating the Strava action schema to track the published API,
+If you are updating the Strava action schema to track the published API or the
+local importer-compatibility layer,
 regenerate it first:
 
 ```bash

--- a/actions/strava.openapi.yaml
+++ b/actions/strava.openapi.yaml
@@ -604,20 +604,6 @@ components:
           type: boolean
         max:
           type: integer
-    TimedZoneDistribution:
-      type: array
-      items:
-        type: object
-        properties:
-          min:
-            type: integer
-            description: The lower bound of the zone range.
-          max:
-            type: integer
-            description: The upper bound of the zone range.
-          time:
-            type: integer
-            description: The number of seconds spent in the zone range.
     SummaryAthlete:
       allOf:
         - $ref: '#/components/schemas/MetaAthlete'
@@ -1328,3 +1314,17 @@ components:
         effort_count:
           type: integer
           description: Number of efforts by the authenticated athlete on this segment.
+    TimedZoneDistribution:
+      type: array
+      items:
+        type: object
+        properties:
+          min:
+            type: integer
+            description: The lower bound of the zone range.
+          max:
+            type: integer
+            description: The upper bound of the zone range.
+          time:
+            type: integer
+            description: The number of seconds spent in the zone range.

--- a/scripts/fixtures/strava_openapi_official_subset.json
+++ b/scripts/fixtures/strava_openapi_official_subset.json
@@ -1939,7 +1939,7 @@
     }
   },
   "spec": {
-    "openapi": "3.0.3",
+    "openapi": "3.1.0",
     "info": {
       "title": "Strava API v3",
       "description": "The [Swagger Playground](https://developers.strava.com/playground) is the easiest way to familiarize yourself with the Strava API by submitting HTTP requests and observing the responses before you write any client code. It will show what a response will look like with different endpoints depending on the authorization scope you receive from your athletes. To use the Playground, go to https://www.strava.com/settings/api and change your “Authorization Callback Domain” to developers.strava.com. Please note, we only support Swagger 2.0. There is a known issue where you can only select one scope at a time. For more information, please check the section “client code” at https://developers.strava.com/docs.",
@@ -2164,7 +2164,7 @@
         "get": {
           "operationId": "getActivityById",
           "summary": "Get Activity",
-          "description": "Returns the given activity that is owned by the authenticated athlete. Requires activity:read for Everyone and Followers activities. Requires activity:read_all for Only Me activities.\n\nWe strongly encourage you to display the appropriate attribution that identifies Garmin as the data source and the device name in your application. Please see example below from VeloViewer (that provides an attribution for a Garmin Forerunner device).\n\n![Attribution](/images/device-attribution-image.png)",
+          "description": "Returns the given activity that is owned by the authenticated athlete. Requires activity:read for Everyone and Followers activities and activity:read_all for Only Me activities.",
           "tags": [
             "Activities"
           ],
@@ -2837,7 +2837,7 @@
               "type": "integer"
             },
             "distribution_buckets": {
-              "$ref": "#/TimedZoneDistribution"
+              "$ref": "#/components/schemas/TimedZoneDistribution"
             },
             "type": {
               "type": "string",
@@ -3867,6 +3867,26 @@
             "effort_count": {
               "type": "integer",
               "description": "Number of efforts by the authenticated athlete on this segment."
+            }
+          }
+        },
+        "TimedZoneDistribution": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "min": {
+                "type": "integer",
+                "description": "The lower bound of the zone range."
+              },
+              "max": {
+                "type": "integer",
+                "description": "The upper bound of the zone range."
+              },
+              "time": {
+                "type": "integer",
+                "description": "The number of seconds spent in the zone range."
+              }
             }
           }
         }

--- a/scripts/strava_openapi.test.cjs
+++ b/scripts/strava_openapi.test.cjs
@@ -8,15 +8,13 @@ const specPath = path.join(__dirname, '..', 'actions', 'strava.openapi.yaml');
 const officialFixturePath = path.join(__dirname, 'fixtures', 'strava_openapi_official_subset.json');
 const spec = yaml.load(fs.readFileSync(specPath, 'utf8'));
 const officialFixture = JSON.parse(fs.readFileSync(officialFixturePath, 'utf8'));
+const localSpecFixture = officialFixture.spec;
 
-test('local Strava action spec matches the vendored official subset exactly', () => {
-  const localWithoutExtension = structuredClone(spec);
-  localWithoutExtension.paths['/activities/{id}/streams'].get.parameters =
-    localWithoutExtension.paths['/activities/{id}/streams'].get.parameters.filter(
-      (parameter) => parameter.name !== 'resolution',
-    );
+const LOCAL_ACTIVITY_DESCRIPTION =
+  'Returns the given activity that is owned by the authenticated athlete. Requires activity:read for Everyone and Followers activities and activity:read_all for Only Me activities.';
 
-  assert.deepEqual(localWithoutExtension, officialFixture.official_spec);
+test('local Strava action spec matches the generated local fixture exactly', () => {
+  assert.deepEqual(spec, localSpecFixture);
 });
 
 test('vendored official subset metadata documents the selected Strava sources', () => {
@@ -31,6 +29,48 @@ test('vendored official subset metadata documents the selected Strava sources', 
   ]);
   assert.ok(officialFixture.source_urls.includes('https://developers.strava.com/swagger/swagger.json'));
   assert.ok(officialFixture.source_urls.includes('https://developers.strava.com/swagger/activity.json'));
+});
+
+test('local Strava action spec documents importer-compatibility transforms explicitly', () => {
+  assert.equal(officialFixture.official_spec.openapi, '3.0.3');
+  assert.equal(spec.openapi, '3.1.0');
+
+  assert.equal(
+    officialFixture.official_spec.paths['/activities/{id}'].get.description.includes('![Attribution]'),
+    true,
+  );
+  assert.equal(spec.paths['/activities/{id}'].get.description, LOCAL_ACTIVITY_DESCRIPTION);
+
+  assert.equal(
+    officialFixture.official_spec.components.schemas.ActivityZone.properties.distribution_buckets.$ref,
+    '#/TimedZoneDistribution',
+  );
+  assert.equal(
+    spec.components.schemas.ActivityZone.properties.distribution_buckets.$ref,
+    '#/components/schemas/TimedZoneDistribution',
+  );
+
+  assert.equal(officialFixture.official_spec.components.schemas.TimedZoneDistribution, undefined);
+  assert.deepEqual(spec.components.schemas.TimedZoneDistribution, {
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        min: {
+          type: 'integer',
+          description: 'The lower bound of the zone range.',
+        },
+        max: {
+          type: 'integer',
+          description: 'The upper bound of the zone range.',
+        },
+        time: {
+          type: 'integer',
+          description: 'The number of seconds spent in the zone range.',
+        },
+      },
+    },
+  });
 });
 
 test('local streams endpoint exposes the optional resolution extension', () => {

--- a/scripts/sync_strava_openapi_subset.cjs
+++ b/scripts/sync_strava_openapi_subset.cjs
@@ -28,6 +28,30 @@ const SECURITY_BY_PATH = {
   '/activities/{id}/zones': [['activity:read'], ['activity:read_all']],
 };
 
+const LOCAL_ACTIVITY_DESCRIPTION =
+  'Returns the given activity that is owned by the authenticated athlete. Requires activity:read for Everyone and Followers activities and activity:read_all for Only Me activities.';
+
+const TIMED_ZONE_DISTRIBUTION_SCHEMA = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      min: {
+        type: 'integer',
+        description: 'The lower bound of the zone range.',
+      },
+      max: {
+        type: 'integer',
+        description: 'The upper bound of the zone range.',
+      },
+      time: {
+        type: 'integer',
+        description: 'The number of seconds spent in the zone range.',
+      },
+    },
+  },
+};
+
 async function fetchJson(url) {
   const response = await fetch(url);
   const text = await response.text();
@@ -247,6 +271,13 @@ function convertSecurityScheme(swagger) {
 }
 
 function applyLocalExtensions(spec) {
+  spec.openapi = '3.1.0';
+  spec.paths['/activities/{id}'].get.description = LOCAL_ACTIVITY_DESCRIPTION;
+  spec.components.schemas.ActivityZone.properties.distribution_buckets = {
+    $ref: '#/components/schemas/TimedZoneDistribution',
+  };
+  spec.components.schemas.TimedZoneDistribution = clone(TIMED_ZONE_DISTRIBUTION_SCHEMA);
+
   const streamParams = spec.paths['/activities/{id}/streams'].get.parameters;
   streamParams.push({
     name: 'resolution',


### PR DESCRIPTION
### Summary
- move the Strava OpenAPI importer-compatibility edits into the sync generator
- regenerate the local action spec and vendored fixture from the updated source of truth
- update the OpenAPI tests to compare against the generated local spec and assert the intentional upstream deltas

### Testing
- task openapi:sync
- task check
- task verify

### Context
- unblocks the Prompt Eval Gate failure surfaced by PR #75 without mixing this repair into the Renovate PR