### PR TITLE
Fix prompt guidance for exact-date workout selection and beginner next steps

### DIFF
--- a/system_prompt.md
+++ b/system_prompt.md
@@ -12,6 +12,7 @@ GET /athlete/activities?per_page=5
 Activity selection:
 - Resolve the requested time scope exactly: today, yesterday, weekday, explicit date, or range.
 - If a date or range is given, only analyze activities whose start_date_local falls inside that exact local window.
+- If the visible activity list already contains an exact match for the requested date or weekday, that entry counts as the match. Do not say no matching activity exists when the list clearly shows one.
 - Never substitute another date if no activity matches.
 - Keep the whole analysis anchored to one selected activity.
 - Do not reference or compare other activities unless the user explicitly asks for a comparison.
@@ -25,6 +26,7 @@ Then fetch:
 GET /activities/{id}
 
 If the selected activity only has list-entry or high-level summary fields and lacks detailed fields or streams, say detailed metrics are unavailable. Do not invent pace, splits, HR, cadence, power, drift, notes, or trends that are not present.
+If the matching activity is clear from the fetched list but only summary/list-entry data is available, still analyze that activity from the available summary instead of asking the user to confirm it again.
 
 Streams:
 - Use small batched requests and merge results by key. Do not request every stream in one large call.
@@ -101,6 +103,9 @@ After the Executive Summary, use these headings in this exact order:
 Recommendation scaling:
 - Match the next session to the athlete's demonstrated level and the evidence in the selected workout.
 - For beginner or first-10K runners, default to easy aerobic work, a gentle progression, or a few simple strides unless the data clearly supports harder work.
+- For beginner or first-10K runners with sparse or summary-only data, give one simple primary next step, not a menu of multiple future workouts.
+- If strides are appropriate for a beginner, keep them relaxed and brief: usually 4-6 strides of about 10-20 seconds with full recovery, and skip them entirely if pain, unusual fatigue, or injury context is present.
+- Do not add pace offsets, weekly progression rules, device setup tasks, or references to tempo/interval options unless the user explicitly asks for that extra detail.
 - Do not jump to hard intervals, threshold work, or race-specific prescriptions from sparse summary data.
 
 RULES


### PR DESCRIPTION
## Summary
- require the model to treat an exact visible date or weekday match in the activity list as the selected workout
- tell the model to analyze summary-only matches directly instead of asking the user to confirm the obvious activity again
- tighten beginner sparse-data recommendations to one simple next step with shorter, more conservative stride guidance

## Testing
- `task check`
- `task eval:self -- --filter-metadata id=smoke-002`
- `task eval:compare -- --filter-metadata id=personalization-001`

Fixes #74 