### PR TITLE
Add local fork version metadata to the generated Strava action spec

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,6 +74,16 @@ reapply the local OpenAI action importer compatibility transforms:
 task openapi:sync
 ```
 
+The generated local action spec intentionally advertises Strava's upstream
+`info.version` with local build metadata such as `3.0.0+strava-coach.1`. The
+vendored `official_spec` fixture keeps the upstream `info.version` unchanged.
+
+When local-only transforms change the generated action spec without a Strava
+upstream version change, increment the `strava-coach.N` suffix in
+[`scripts/sync_strava_openapi_subset.cjs`](./scripts/sync_strava_openapi_subset.cjs)
+and rerun `task openapi:sync` so the generated spec advertises a new local fork
+revision.
+
 Run pre-commit on all tracked files:
 
 ```bash

--- a/actions/strava.openapi.yaml
+++ b/actions/strava.openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Strava API v3
   description: The [Swagger Playground](https://developers.strava.com/playground) is the easiest way to familiarize yourself with the Strava API by submitting HTTP requests and observing the responses before you write any client code. It will show what a response will look like with different endpoints depending on the authorization scope you receive from your athletes. To use the Playground, go to https://www.strava.com/settings/api and change your “Authorization Callback Domain” to developers.strava.com. Please note, we only support Swagger 2.0. There is a known issue where you can only select one scope at a time. For more information, please check the section “client code” at https://developers.strava.com/docs.
-  version: 3.0.0
+  version: 3.0.0+strava-coach.1
 servers:
   - url: https://www.strava.com/api/v3
 security:

--- a/scripts/fixtures/strava_openapi_official_subset.json
+++ b/scripts/fixtures/strava_openapi_official_subset.json
@@ -1943,7 +1943,7 @@
     "info": {
       "title": "Strava API v3",
       "description": "The [Swagger Playground](https://developers.strava.com/playground) is the easiest way to familiarize yourself with the Strava API by submitting HTTP requests and observing the responses before you write any client code. It will show what a response will look like with different endpoints depending on the authorization scope you receive from your athletes. To use the Playground, go to https://www.strava.com/settings/api and change your “Authorization Callback Domain” to developers.strava.com. Please note, we only support Swagger 2.0. There is a known issue where you can only select one scope at a time. For more information, please check the section “client code” at https://developers.strava.com/docs.",
-      "version": "3.0.0"
+      "version": "3.0.0+strava-coach.1"
     },
     "servers": [
       {

--- a/scripts/strava_openapi.test.cjs
+++ b/scripts/strava_openapi.test.cjs
@@ -12,6 +12,8 @@ const localSpecFixture = officialFixture.spec;
 
 const LOCAL_ACTIVITY_DESCRIPTION =
   'Returns the given activity that is owned by the authenticated athlete. Requires activity:read for Everyone and Followers activities and activity:read_all for Only Me activities.';
+const UPSTREAM_SPEC_VERSION = '3.0.0';
+const LOCAL_SPEC_VERSION = '3.0.0+strava-coach.1';
 
 test('local Strava action spec matches the generated local fixture exactly', () => {
   assert.deepEqual(spec, localSpecFixture);
@@ -34,6 +36,8 @@ test('vendored official subset metadata documents the selected Strava sources', 
 test('local Strava action spec documents importer-compatibility transforms explicitly', () => {
   assert.equal(officialFixture.official_spec.openapi, '3.0.3');
   assert.equal(spec.openapi, '3.1.0');
+  assert.equal(officialFixture.official_spec.info.version, UPSTREAM_SPEC_VERSION);
+  assert.equal(spec.info.version, LOCAL_SPEC_VERSION);
 
   assert.equal(
     officialFixture.official_spec.paths['/activities/{id}'].get.description.includes('![Attribution]'),

--- a/scripts/sync_strava_openapi_subset.cjs
+++ b/scripts/sync_strava_openapi_subset.cjs
@@ -30,6 +30,7 @@ const SECURITY_BY_PATH = {
 
 const LOCAL_ACTIVITY_DESCRIPTION =
   'Returns the given activity that is owned by the authenticated athlete. Requires activity:read for Everyone and Followers activities and activity:read_all for Only Me activities.';
+const LOCAL_FORK_BUILD_METADATA = 'strava-coach.1';
 
 const TIMED_ZONE_DISTRIBUTION_SCHEMA = {
   type: 'array',
@@ -271,7 +272,10 @@ function convertSecurityScheme(swagger) {
 }
 
 function applyLocalExtensions(spec) {
+  // Keep the OpenAPI document format version separate from the Strava upstream
+  // API version while making the local fork revision explicit to consumers.
   spec.openapi = '3.1.0';
+  spec.info.version = `${spec.info.version}+${LOCAL_FORK_BUILD_METADATA}`;
   spec.paths['/activities/{id}'].get.description = LOCAL_ACTIVITY_DESCRIPTION;
   spec.components.schemas.ActivityZone.properties.distribution_buckets = {
     $ref: '#/components/schemas/TimedZoneDistribution',


### PR DESCRIPTION
## Summary
- append `+strava-coach.1` to the generated local Strava action spec `info.version`
- keep the vendored `official_spec` fixture on Strava's upstream `3.0.0` version
- extend the OpenAPI sync test to assert both upstream and local version values
- document how to bump the local `strava-coach.N` suffix for future local-only spec changes

## Testing
- `task verify`
- `task openapi:sync`

Fixes #77 