### PR TITLE
Fix CI issue-reference checks for edited pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,9 @@ runtime code.
   messages reference that issue.
 - Use a plain reference like `#42` by default when the work is part of the
   issue but does not fully resolve it.
-- Let the PR creator decide whether to add a closing keyword such as
-  `Fixes #42` in the PR body when the PR fully resolves the issue.
+- Make an explicit call about whether the merged change fully resolves the
+  issue. When it does, the agent may add a closing keyword such as `Fixes #42`
+  in the PR body and/or a relevant commit message.
 - Only use closing keywords when the merged change fully resolves the issue. If
   the issue is only partially addressed, reference it without auto-closing it.
 - Keep docs synchronized with workflow changes. If CI behavior or eval policy

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -292,9 +292,9 @@ Useful references:
   `implement-github-issue-42`, make sure the PR title, PR body, or commit
   messages reference `#42` so branch-name validation can tie the work back to
   the issue.
-- Reserve closing keywords like `Fixes #42` for work that fully resolves the
-  issue when merged, and prefer putting that decision in the PR body so the PR
-  creator stays accountable for whether the issue should actually close.
+- Follow the issue-closing policy in [`AGENTS.md`](./AGENTS.md): use a plain
+  issue reference by default, and use a closing keyword like `Fixes #42` only
+  when the merged change fully resolves the issue.
 - Edit [`system_prompt.md`](./system_prompt.md), not the published wrapper page
   in [`content/system-prompt.md`](./content/system-prompt.md).
 - Use `task` commands in docs, reviews, and agent responses unless you are

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -170,9 +170,7 @@ gh workflow run prompt-eval.yml --ref main -f run_nightly_full=true
 Usually nothing beyond local `pre-commit`.
 
 If the branch name includes an issue token such as `issue-42`, make sure the PR
-title, PR body, or commit messages reference that issue. Use `Fixes #42` only
-when the PR truly resolves the issue on merge, and prefer putting that closing
-intent in the PR body so the PR creator makes that call explicitly.
+title, PR body, or commit messages reference that issue.
 
 If you touched layouts, Hugo config, or rendering behavior, also run:
 
@@ -267,9 +265,6 @@ When a PR branch name explicitly carries an issue number, for example
 - the PR title, PR body, or commit messages in that PR to reference `#26`
 
 The guardrail accepts either a plain issue reference such as `#26` or a full
-issue URL. Prefer a plain reference unless the PR or commit should actually
-close the issue on merge.
-
-If the PR really should close the issue, the PR creator should add a closing
-keyword such as `Fixes #26` in the PR body. That choice is intentionally manual
-so branch naming and commit tooling do not accidentally close issues.
+issue URL. Prefer a plain reference by default. If the merged change fully
+resolves the issue, make that call explicitly and use a closing keyword such as
+`Fixes #26` in the PR body and/or a relevant commit message.


### PR DESCRIPTION
## Summary
- Run the `CI` workflow on `pull_request.edited` so PR title/body updates retrigger issue-reference validation
- Keep the change scoped to `CI` rather than expanding metadata-only reruns to prompt-eval workflows
- Document the new trigger behavior in `docs/CI.md`, including that prompt-eval workflows still do not run for PR title/body-only edits

## Testing
- `task verify`