### PR TITLE
Fix canary bad-sample budgeting for infrastructure errors

### DIFF
--- a/evals/promptfoo/canary_summary.cjs
+++ b/evals/promptfoo/canary_summary.cjs
@@ -146,17 +146,15 @@ function createRunReport({ artifactDir, phaseReports, canaryConfig }) {
         counts[sample.status === 'error' ? 'errors' : sample.status] += 1;
       }
 
+      const sampleCount = entry.samples.length;
+      const badSampleCount = counts.failed + counts.errors;
       let status = 'passed';
-      if (counts.errors > 0) {
-        status = 'error';
-      } else if (counts.failed > canaryConfig.allowed_failures) {
+      if (badSampleCount > canaryConfig.allowed_failures) {
         status = 'failed';
-      } else if (counts.failed > 0) {
+      } else if (badSampleCount > 0) {
         status = 'warning';
       }
 
-      const sampleCount = entry.samples.length;
-      const badSampleCount = counts.failed + counts.errors;
       return {
         suite: entry.suite,
         id: entry.id,
@@ -180,16 +178,14 @@ function createRunReport({ artifactDir, phaseReports, canaryConfig }) {
   const passed = tests.filter((test) => test.status === 'passed').length;
   const warnings = tests.filter((test) => test.status === 'warning').length;
   const failed = tests.filter((test) => test.status === 'failed').length;
-  const errors = tests.filter((test) => test.status === 'error').length;
+  const errors = 0;
   const samples = tests.reduce((total, test) => total + test.sampleCount, 0);
   const samplePasses = tests.reduce((total, test) => total + test.passedSamples, 0);
   const sampleFailures = tests.reduce((total, test) => total + test.failedSamples, 0);
   const sampleErrors = tests.reduce((total, test) => total + test.errorSamples, 0);
 
   let result = 'PASS';
-  if (errors > 0) {
-    result = 'ERROR';
-  } else if (failed > 0) {
+  if (failed > 0) {
     result = 'FAIL';
   } else if (warnings > 0) {
     result = 'WARN';
@@ -383,7 +379,7 @@ function main(argv = process.argv.slice(2)) {
     summaryPath,
   }));
   appendGithubStepSummary(runReport);
-  if (args.check && (runReport.result === 'FAIL' || runReport.result === 'ERROR')) {
+  if (args.check && runReport.result === 'FAIL') {
     process.exit(1);
   }
 }

--- a/evals/promptfoo/canary_summary.test.cjs
+++ b/evals/promptfoo/canary_summary.test.cjs
@@ -105,6 +105,32 @@ test('createRunReport warns on a single unlucky sample within the allowed budget
   assert.match(buildMarkdownSummary(runReport), /WARNING smoke\/smoke-005/);
 });
 
+test('createRunReport warns on a single infrastructure error within the allowed budget', () => {
+  const runReport = createRunReport({
+    artifactDir: '/tmp/artifacts',
+    phaseReports: [
+      makePhaseReport([
+        makeRow({ id: 'smoke-004', repeatIndex: 0 }),
+        makeRow({ id: 'smoke-004', repeatIndex: 1, error: 'Evaluation timed out after 90000ms' }),
+        makeRow({ id: 'smoke-004', repeatIndex: 2 }),
+        makeRow({ id: 'smoke-004', repeatIndex: 3 }),
+        makeRow({ id: 'smoke-004', repeatIndex: 4 }),
+      ]),
+    ],
+    canaryConfig: {
+      repeat: 5,
+      allowed_failures: 1,
+      temperature: 1,
+    },
+  });
+
+  assert.equal(runReport.result, 'WARN');
+  assert.equal(runReport.tests[0].status, 'warning');
+  assert.equal(runReport.tests[0].failedSamples, 0);
+  assert.equal(runReport.tests[0].errorSamples, 1);
+  assert.match(buildMarkdownSummary(runReport), /WARNING smoke\/smoke-004/);
+});
+
 test('createRunReport fails when repeated bad samples exceed the allowed budget', () => {
   const runReport = createRunReport({
     artifactDir: '/tmp/artifacts',
@@ -127,6 +153,31 @@ test('createRunReport fails when repeated bad samples exceed the allowed budget'
   assert.equal(runReport.result, 'FAIL');
   assert.equal(runReport.tests[0].status, 'failed');
   assert.equal(runReport.tests[0].failedSamples, 2);
+});
+
+test('createRunReport fails when mixed bad samples exceed the allowed budget', () => {
+  const runReport = createRunReport({
+    artifactDir: '/tmp/artifacts',
+    phaseReports: [
+      makePhaseReport([
+        makeRow({ id: 'smoke-004', repeatIndex: 0, success: false, reason: 'First bad sample.' }),
+        makeRow({ id: 'smoke-004', repeatIndex: 1, error: 'Evaluation timed out after 90000ms' }),
+        makeRow({ id: 'smoke-004', repeatIndex: 2 }),
+        makeRow({ id: 'smoke-004', repeatIndex: 3 }),
+        makeRow({ id: 'smoke-004', repeatIndex: 4 }),
+      ]),
+    ],
+    canaryConfig: {
+      repeat: 5,
+      allowed_failures: 1,
+      temperature: 1,
+    },
+  });
+
+  assert.equal(runReport.result, 'FAIL');
+  assert.equal(runReport.tests[0].status, 'failed');
+  assert.equal(runReport.tests[0].failedSamples, 1);
+  assert.equal(runReport.tests[0].errorSamples, 1);
 });
 
 test('createRunReport treats self-grading assertion details in row.error as failed samples, not infrastructure errors', () => {
@@ -178,9 +229,11 @@ test('writeSummary writes markdown and json outputs for the canary lane', () => 
     artifactDir: tempDir,
   });
 
-  assert.equal(runReport.result, 'ERROR');
+  assert.equal(runReport.result, 'WARN');
   assert.ok(fs.existsSync(summaryPath));
   assert.ok(fs.existsSync(jsonOutputPath));
   assert.match(fs.readFileSync(summaryPath, 'utf8'), /Smoke Canary Outcome/);
-  assert.match(fs.readFileSync(jsonOutputPath, 'utf8'), /"result": "ERROR"/);
+  assert.match(fs.readFileSync(summaryPath, 'utf8'), /WARNING smoke\/smoke-001/);
+  assert.match(fs.readFileSync(jsonOutputPath, 'utf8'), /"result": "WARN"/);
+  assert.match(fs.readFileSync(jsonOutputPath, 'utf8'), /"errorSamples": 1/);
 });


### PR DESCRIPTION
## Summary
- budget infrastructure errors and assertion failures together when evaluating canary repeats
- downgrade a single bad sample within `allowed_failures` to `WARN` instead of forcing `ERROR`
- keep separate failure and error counters in the canary report while failing only when the bad-sample budget is exceeded
- extend canary summary tests to cover single-error warnings, mixed over-budget failures, and updated summary output expectations

## Testing
- `node --test evals/promptfoo/canary_summary.test.cjs`
- `task verify`