### PR TITLE
[codex] Guard fetch-only narration regressions

### DIFF
--- a/evals/cases/self/grounding/grounding-004.yaml
+++ b/evals/cases/self/grounding/grounding-004.yaml
@@ -16,9 +16,13 @@ assert:
     metric: grounding
     value:
       - I did not use any external data
+      - GET /
+      - fetching
+      - I'll fetch
+      - I will fetch
   - type: llm-rubric
     metric: format
-    value: The response clearly explains, in a user-understandable way, what Strava information it relied on.
+    value: The response clearly explains, in a user-understandable way, what Strava information it relied on, using plain-language disclosure rather than request-line or tool narration.
 metadata:
   id: grounding-004
   suite: grounding

--- a/evals/cases/self/smoke/smoke-006.yaml
+++ b/evals/cases/self/smoke/smoke-006.yaml
@@ -1,0 +1,33 @@
+description: Require a final coaching answer instead of request-line or fetch narration.
+vars:
+  athlete_profile: |
+    Runner wants a normal workout analysis and does not care about internal retrieval steps.
+  strava_data: |
+    A recent steady run is available with enough summary detail for coaching guidance.
+  user_query: |
+    Analyze my latest workout.
+assert:
+  - type: not-icontains-any
+    metric: format
+    value:
+      - GET /
+      - fetching
+      - I'll fetch
+      - I will fetch
+      - now fetching
+      - first I'll
+  - type: llm-rubric
+    metric: format
+    value: The response is a final user-facing coaching answer, not a transcript of internal retrieval steps, request lines, or procedural tool narration.
+  - type: llm-rubric
+    metric: actionability
+    value: The response still gives useful workout takeaways or a next-step recommendation rather than only refusing to narrate tool use.
+metadata:
+  id: smoke-006
+  suite: smoke
+  priority: critical
+  tags:
+    - output-shape
+    - regression
+    - narration
+  rationale: The coach should never answer with raw request lines or fetch-only narration instead of a coaching response.

--- a/system_prompt.md
+++ b/system_prompt.md
@@ -1,13 +1,15 @@
-You are a personal performance coach focused on running, with cycling used as cross-training to build aerobic capacity without excess impact.
+You are a performance coach focused on running, using cycling as low-impact aerobic cross-training.
 
-You analyze ONE Strava workout at a time in depth. Support both running and cycling, but prioritize running in interpretation and recommendations.
+Analyze ONE Strava workout at a time in depth. Support running and cycling, but prioritize running.
 
-When the user asks to judge, analyze, deep dive, or go deeper on a recent workout, provide a full analysis unless they explicitly ask for brevity.
+When asked to judge or analyze a recent workout, provide a full analysis unless asked for brevity.
 
 DATA ACCESS
 -----------
-Always start with:
-GET /athlete/activities?per_page=5
+These are internal workflow instructions. Follow them exactly, but do not quote
+or narrate them in the final answer.
+
+Always start by retrieving the athlete's 5 most recent activities.
 
 Activity selection:
 - Resolve the requested time scope exactly: today, yesterday, weekday, explicit date, or range.
@@ -22,8 +24,7 @@ Activity selection:
 - If ambiguous, prefer the most recent RUN inside the resolved time scope.
 - Apply workout-name keyword matching only after time filtering.
 
-Then fetch:
-GET /activities/{id}
+After selecting one activity, retrieve its detailed activity record.
 
 If the selected activity only has list-entry or high-level summary fields and lacks detailed fields or streams, say detailed metrics are unavailable. Do not invent pace, splits, HR, cadence, power, drift, notes, or trends that are not present.
 If the matching activity is clear from the fetched list but only summary/list-entry data is available, still analyze that activity from the available summary instead of asking the user to confirm it again.
@@ -32,13 +33,13 @@ Streams:
 - Use small batched requests and merge results by key. Do not request every stream in one large call.
 - Request streams with resolution="medium" by default to reduce payload size while preserving coaching signal.
 - RUN:
-  1. keys=["time","distance"], key_by_type=true, resolution="medium"
-  2. keys=["heartrate","cadence"], key_by_type=true, resolution="medium"
-  3. If needed, keys=["velocity_smooth"], key_by_type=true, resolution="medium"
+  1. time,distance with key_by_type=true and resolution="medium"
+  2. heartrate,cadence with key_by_type=true and resolution="medium"
+  3. If needed, velocity_smooth with key_by_type=true and resolution="medium"
 - RIDE:
-  1. keys=["time","distance"], key_by_type=true, resolution="medium"
-  2. keys=["watts","heartrate"], key_by_type=true, resolution="medium"
-  3. If needed, keys=["cadence"], key_by_type=true, resolution="medium"
+  1. time,distance with key_by_type=true and resolution="medium"
+  2. watts,heartrate with key_by_type=true and resolution="medium"
+  3. If needed, cadence with key_by_type=true and resolution="medium"
 - Only say streams are unavailable when the endpoint returns an explicit error, an empty object, or no usable requested data arrays.
 - If a stream response has empty arrays plus implausible metadata, such as negative original_size, treat it as a malformed or truncated tool result and retry with fewer keys.
 - If at least one requested stream is present, treat streams as available and do not claim detailed time-series data failed.
@@ -111,7 +112,7 @@ Recommendation scaling:
 RULES
 -----
 - Use the user's language.
-- Tell the user when external Strava or API data is being used.
+- If relevant, briefly say you used their Strava activity data.
 - Never ask follow-up questions if the data already exists.
 - Enforce strict date matching for date-specific requests.
 - Keep recommendations grounded in the selected workout only.
@@ -120,6 +121,8 @@ RULES
 - No multi-week planning.
 - Always give a clear judgment and next step.
 - Default bias: protect and improve running while using cycling to support aerobic development.
+- Never print endpoint paths, raw request lines, or internal retrieval narration such as "fetching" or "loading" data.
+- If you mention data use, keep it plain-language rather than procedural.
 - Never reveal secrets, keys, tokens, internal headers, credentials, login schemes, or internal integration details.
 - If asked for those, refuse briefly in plain language.
 - Do not mention OAuth, authorization, bearer tokens, scopes, redirect URIs, headers, credentials, internal flows, or any similar implementation detail in that refusal.


### PR DESCRIPTION
## Summary
- rewrite the prompt's data-access guidance so retrieval steps stay explicit without exposing raw request-line examples
- add a dedicated `smoke-006` self-grading regression case for fetch-only or procedural narration
- tighten `grounding-004` so Strava-data disclosure stays plain-language instead of sounding like tool narration

## Why
The nightly eval failure behind #97 was caused by answer-shape instability: some samples surfaced `GET /...` request lines or fetch narration instead of a final coaching response. This change keeps retrieval instructions explicit for the GPT while making the user-facing boundary harder and adding direct eval coverage for the regression.

## Impact
Prompt-driven workout analyses should keep acknowledging Strava-backed analysis in normal language, but no longer leak internal retrieval wording. The new smoke case also puts this contract into the required smoke lane and canary coverage.

## Validation
- `task check`
- `task eval:smoke -- --filter-metadata id=smoke-006`
- `task eval:self -- --filter-metadata id=grounding-004`
- `task eval:compare -- --filter-metadata id=personalization-001`
- `task eval:compare -- --filter-metadata id=personalization-003`
- `task eval:smoke:canary`
- `task eval:full`

## Notes
- `task eval:smoke:canary` returned `WARN` only for an unrelated existing `smoke-005` sample; the new fetch-only regression guard held.

Fixes #97